### PR TITLE
Refactor Tile.java

### DIFF
--- a/integrations/beast3/java/src/main/java/Test2.java
+++ b/integrations/beast3/java/src/main/java/Test2.java
@@ -7,32 +7,9 @@ public class Test2 {
 
     static void main(String[] args) throws IOException, ParserConfigurationException, SAXException {
         String source = """
-                Alignment data[i] = fromNexus("/Users/ochsneto/Documents/PhyloSpec/beast3/beast-base/src/test/resources/beast.base/examples/nexus/primate-mtDNA.nex") for i in 1:2
-                
-                Tree tree[i] ~ Yule(
-                    birthRate=1.0, taxa=taxa(data[i])
-                ) for i in 1:num(data)
-                
-                QMatrix qMatrix[i] = hky(
-                    kappa~LogNormal(logMean=1.0, logSd=0.5),
-                    baseFrequencies~Dirichlet(repeat(1.0, num=4))
-                ) for i in 1:num(data)
-                
-                Vector<Rate> branchRates[i] ~ RelaxedClock(
-                    clockRate=10,
-                    base=LogNormal(mean=1.0, logSd=2.0),
-                    tree=tree[i]
-                ) for i in 1:num(data)
-                
-                Vector<Rate> siteRates[i] ~ DiscreteGammaInv(
-                     shape~LogNormal(mean=1.0, logSd=0.05),
-                     numCategories=4,
-                     numSites=numSites(data[i])
-                ) for i in 1:num(data)
-                
-                Alignment alignment[i] ~ PhyloCTMC(
-                    tree=tree[i], qMatrix=qMatrix[1], branchRates=branchRates[i], siteRates=siteRates[i]
-                ) observed as data[i] for i in 1:num(data)
+              Tree data = fromNewick("file.newick")
+              Rate birthRate ~ LogNormal(mean=1.0, logSd=2.0)
+              Tree tree ~ Yule(birthRate, taxa=taxa(data)) observed as data
         """;
 
         PhyloSpecRunner parser = new PhyloSpecRunner(source);

--- a/integrations/beast3/java/src/main/java/tiles/AstNodeTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/AstNodeTile.java
@@ -6,6 +6,7 @@ import org.phylospec.typeresolver.StochasticityResolver;
 import org.phylospec.typeresolver.VariableResolver;
 import tiling.FailedTilingAttempt;
 import tiling.Tile;
+import tiling.TileFactory;
 import tiling.TileInput;
 
 import java.lang.reflect.Field;
@@ -17,7 +18,7 @@ import java.util.function.Function;
  * This class represents tiles that cover a single AstNode of type N. Extend this class for custom tiles.
  * Use AstNodeTileInput fields to specify the tile inputs (similar to BEAST 2.8 inputs).
  */
-public abstract class AstNodeTile<T, N extends AstNode> extends Tile<T> {
+public abstract class AstNodeTile<T, N extends AstNode> extends Tile<T> implements TileFactory {
 
     public Class<N> getTargetNodeType() {
         return (Class<N>) ((ParameterizedType) getClass().getGenericSuperclass())

--- a/integrations/beast3/java/src/main/java/tiles/AstNodeTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/AstNodeTile.java
@@ -60,8 +60,7 @@ public abstract class AstNodeTile<T, N extends AstNode> extends Tile<T> implemen
 
             if (compatibleInputs.isEmpty()) {
                 throw new FailedTilingAttempt.RejectedBoundary(
-                        "BEAST 2.8 cannot deal with the value you provided for " + tileInput.getKey() + ".",
-                        node
+                        "BEAST 2.8 cannot deal with the value you provided for " + tileInput.getKey() + "."
                 );
             }
 

--- a/integrations/beast3/java/src/main/java/tiles/AstNodeTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/AstNodeTile.java
@@ -6,7 +6,7 @@ import org.phylospec.typeresolver.StochasticityResolver;
 import org.phylospec.typeresolver.VariableResolver;
 import tiling.FailedTilingAttempt;
 import tiling.Tile;
-import tiling.TileFactory;
+import tiling.CandidateTile;
 import tiling.TileInput;
 
 import java.lang.reflect.Field;
@@ -18,7 +18,7 @@ import java.util.function.Function;
  * This class represents tiles that cover a single AstNode of type N. Extend this class for custom tiles.
  * Use AstNodeTileInput fields to specify the tile inputs (similar to BEAST 2.8 inputs).
  */
-public abstract class AstNodeTile<T, N extends AstNode> extends Tile<T> implements TileFactory {
+public abstract class AstNodeTile<T, N extends AstNode> extends Tile<T> implements CandidateTile {
 
     public Class<N> getTargetNodeType() {
         return (Class<N>) ((ParameterizedType) getClass().getGenericSuperclass())

--- a/integrations/beast3/java/src/main/java/tiles/BeastCoreTileLibrary.java
+++ b/integrations/beast3/java/src/main/java/tiles/BeastCoreTileLibrary.java
@@ -17,6 +17,7 @@ import tiling.Tile;
 import tiles.distributions.*;
 import tiles.misc.*;
 import tiles.substitutionmodels.*;
+import tiling.TileFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,8 +28,8 @@ import java.util.List;
 public class BeastCoreTileLibrary extends TileLibrary {
 
     @Override
-    public List<Tile<?>> getTiles() {
-        List<Tile<?>> tiles = new ArrayList<>();
+    public List<TileFactory> getTiles() {
+        List<TileFactory> tiles = new ArrayList<>();
 
         tiles.add(new AssignmentTile());
         tiles.add(new DrawTile());

--- a/integrations/beast3/java/src/main/java/tiles/BeastCoreTileLibrary.java
+++ b/integrations/beast3/java/src/main/java/tiles/BeastCoreTileLibrary.java
@@ -13,11 +13,10 @@ import tiles.mcmc.*;
 import tiles.observations.*;
 import tiles.sitemodels.*;
 import tiles.trees.*;
-import tiling.Tile;
 import tiles.distributions.*;
 import tiles.misc.*;
 import tiles.substitutionmodels.*;
-import tiling.TileFactory;
+import tiling.CandidateTile;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +27,8 @@ import java.util.List;
 public class BeastCoreTileLibrary extends TileLibrary {
 
     @Override
-    public List<TileFactory> getTiles() {
-        List<TileFactory> tiles = new ArrayList<>();
+    public List<CandidateTile> getTiles() {
+        List<CandidateTile> tiles = new ArrayList<>();
 
         tiles.add(new AssignmentTile());
         tiles.add(new DrawTile());

--- a/integrations/beast3/java/src/main/java/tiles/GeneratorTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/GeneratorTile.java
@@ -7,6 +7,7 @@ import org.phylospec.typeresolver.StochasticityResolver;
 import org.phylospec.typeresolver.VariableResolver;
 import tiling.FailedTilingAttempt;
 import tiling.Tile;
+import tiling.TileFactory;
 import tiling.TileInput;
 
 import java.lang.reflect.Field;
@@ -17,7 +18,7 @@ import java.util.stream.Collectors;
  * This class represents tiles that cover a single generator call. Extend this class for custom tiles.
  * Use GeneratorTileInput fields to specify the tile inputs (similar to BEAST 2.8 inputs).
  */
-public abstract class GeneratorTile<T> extends Tile<T> {
+public abstract class GeneratorTile<T> extends Tile<T> implements TileFactory {
 
     public abstract String getPhyloSpecGeneratorName();
 

--- a/integrations/beast3/java/src/main/java/tiles/GeneratorTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/GeneratorTile.java
@@ -75,8 +75,7 @@ public abstract class GeneratorTile<T> extends Tile<T> implements TileFactory {
 
             if (currentCompatibleInputTiles.isEmpty()) {
                 throw new FailedTilingAttempt.RejectedBoundary(
-                        "BEAST 2.8 cannot deal with the value you provided for the '" + argumentName + "' argument for '" + this.getPhyloSpecGeneratorName() + "'.",
-                        argument
+                        "BEAST 2.8 cannot deal with the value you provided for the '" + argumentName + "' argument for '" + this.getPhyloSpecGeneratorName() + "'."
                 );
             }
 

--- a/integrations/beast3/java/src/main/java/tiles/GeneratorTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/GeneratorTile.java
@@ -7,7 +7,7 @@ import org.phylospec.typeresolver.StochasticityResolver;
 import org.phylospec.typeresolver.VariableResolver;
 import tiling.FailedTilingAttempt;
 import tiling.Tile;
-import tiling.TileFactory;
+import tiling.CandidateTile;
 import tiling.TileInput;
 
 import java.lang.reflect.Field;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  * This class represents tiles that cover a single generator call. Extend this class for custom tiles.
  * Use GeneratorTileInput fields to specify the tile inputs (similar to BEAST 2.8 inputs).
  */
-public abstract class GeneratorTile<T> extends Tile<T> implements TileFactory {
+public abstract class GeneratorTile<T> extends Tile<T> implements CandidateTile {
 
     public abstract String getPhyloSpecGeneratorName();
 

--- a/integrations/beast3/java/src/main/java/tiles/TemplateTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/TemplateTile.java
@@ -92,8 +92,7 @@ public abstract class TemplateTile<T> extends Tile<T> implements TileFactory {
             Set<Tile<?>> compatible = tileInput.getCompatibleInputTiles(inputAstNode, allInputTiles, stochasticityResolver);
             if (compatible.isEmpty()) {
                 throw new FailedTilingAttempt.RejectedBoundary(
-                        "BEAST 2.8 cannot deal with the value you provided for " + tileInput.getKey().replace("$", "") + ".",
-                        inputAstNode
+                        "BEAST 2.8 cannot deal with the value you provided for " + tileInput.getKey().replace("$", "") + "."
                 );
             }
 

--- a/integrations/beast3/java/src/main/java/tiles/TemplateTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/TemplateTile.java
@@ -7,6 +7,7 @@ import org.phylospec.typeresolver.VariableResolver;
 import templatematching.AstTemplateMatcher;
 import tiling.FailedTilingAttempt;
 import tiling.Tile;
+import tiling.TileFactory;
 import tiling.TileInput;
 
 import java.lang.reflect.Field;
@@ -17,7 +18,7 @@ import java.util.*;
  * PhyloSpec template used to match the AST subgraph.
  * Use TemplateTileInput fields to specify the tile inputs (similar to BEAST 2.8 inputs).
  */
-public abstract class TemplateTile<T> extends Tile<T> {
+public abstract class TemplateTile<T> extends Tile<T> implements TileFactory {
 
     protected abstract String getPhyloSpecTemplate();
 

--- a/integrations/beast3/java/src/main/java/tiles/TemplateTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/TemplateTile.java
@@ -7,7 +7,7 @@ import org.phylospec.typeresolver.VariableResolver;
 import templatematching.AstTemplateMatcher;
 import tiling.FailedTilingAttempt;
 import tiling.Tile;
-import tiling.TileFactory;
+import tiling.CandidateTile;
 import tiling.TileInput;
 
 import java.lang.reflect.Field;
@@ -18,7 +18,7 @@ import java.util.*;
  * PhyloSpec template used to match the AST subgraph.
  * Use TemplateTileInput fields to specify the tile inputs (similar to BEAST 2.8 inputs).
  */
-public abstract class TemplateTile<T> extends Tile<T> implements TileFactory {
+public abstract class TemplateTile<T> extends Tile<T> implements CandidateTile {
 
     protected abstract String getPhyloSpecTemplate();
 

--- a/integrations/beast3/java/src/main/java/tiles/TileLibrary.java
+++ b/integrations/beast3/java/src/main/java/tiles/TileLibrary.java
@@ -1,6 +1,7 @@
 package tiles;
 
 import tiling.Tile;
+import tiling.TileFactory;
 
 import java.util.List;
 import java.util.ServiceLoader;
@@ -9,11 +10,11 @@ import java.util.ArrayList;
 public abstract class TileLibrary {
 
     /** Returns all tiles registered in this library. */
-    public abstract List<Tile<?>> getTiles();
+    public abstract List<TileFactory> getTiles();
 
     /** Discovers all TileLibrary implementations on the classpath and collects their tiles. */
-    public static List<Tile<?>> loadAll() {
-        List<Tile<?>> all = new ArrayList<>();
+    public static List<TileFactory> loadAll() {
+        List<TileFactory> all = new ArrayList<>();
         for (TileLibrary library : ServiceLoader.load(TileLibrary.class)) {
             all.addAll(library.getTiles());
         }

--- a/integrations/beast3/java/src/main/java/tiles/TileLibrary.java
+++ b/integrations/beast3/java/src/main/java/tiles/TileLibrary.java
@@ -1,7 +1,6 @@
 package tiles;
 
-import tiling.Tile;
-import tiling.TileFactory;
+import tiling.CandidateTile;
 
 import java.util.List;
 import java.util.ServiceLoader;
@@ -10,11 +9,11 @@ import java.util.ArrayList;
 public abstract class TileLibrary {
 
     /** Returns all tiles registered in this library. */
-    public abstract List<TileFactory> getTiles();
+    public abstract List<CandidateTile> getTiles();
 
     /** Discovers all TileLibrary implementations on the classpath and collects their tiles. */
-    public static List<TileFactory> loadAll() {
-        List<TileFactory> all = new ArrayList<>();
+    public static List<CandidateTile> loadAll() {
+        List<CandidateTile> all = new ArrayList<>();
         for (TileLibrary library : ServiceLoader.load(TileLibrary.class)) {
             all.addAll(library.getTiles());
         }

--- a/integrations/beast3/java/src/main/java/tiles/misc/LiteralTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/misc/LiteralTile.java
@@ -113,7 +113,7 @@ public class LiteralTile<T> extends AstNodeTile<T, Expr.Literal> {
     }
 
     @Override
-    protected Tile<?> createInstance() {
+    public Tile<?> createInstance() {
         return new LiteralTile<>(new TypeToken<>() {
         }, null, null);
     }

--- a/integrations/beast3/java/src/main/java/tiles/misc/VectorTile.java
+++ b/integrations/beast3/java/src/main/java/tiles/misc/VectorTile.java
@@ -36,7 +36,7 @@ public class VectorTile<T> extends AstNodeTile<T, Expr.Array> {
     }
 
     @Override
-    protected Set<Stochasticity> getCompatibleStochasticities() {
+    public Set<Stochasticity> getCompatibleStochasticities() {
         return Set.of(Stochasticity.CONSTANT, Stochasticity.DETERMINISTIC);
     }
 
@@ -174,7 +174,7 @@ public class VectorTile<T> extends AstNodeTile<T, Expr.Array> {
     }
 
     @Override
-    protected Tile<?> createInstance() {
+    public Tile<?> createInstance() {
         return new VectorTile<>(new TypeToken<>() {
         }, null);
     }

--- a/integrations/beast3/java/src/main/java/tiling/CandidateTile.java
+++ b/integrations/beast3/java/src/main/java/tiling/CandidateTile.java
@@ -11,7 +11,7 @@ import java.util.*;
 /**
  * This interface provides methods to construct tiles for a subgraph of the PhyloSpec AST.
  */
-public interface TileFactory {
+public interface CandidateTile {
 
     /**
      * Tries to tile this tile to the AST subgraph starting with 'node'. Has to be overridden by custom tile factories.

--- a/integrations/beast3/java/src/main/java/tiling/CandidateTile.java
+++ b/integrations/beast3/java/src/main/java/tiling/CandidateTile.java
@@ -14,7 +14,7 @@ import java.util.*;
 public interface CandidateTile {
 
     /**
-     * Tries to tile this tile to the AST subgraph starting with 'node'. Has to be overridden by custom tile factories.
+     * Tries to tile this tile to the AST subgraph starting with 'node'. Has to be overridden by custom candidate tiles.
      * Returns a set of the possible tilings.
      */
     Set<Tile<?>> tryToTile(
@@ -87,12 +87,12 @@ public interface CandidateTile {
 
     /**
      * Creates a new instance of the corresponding tile.
-     * The default method assumes that the tile itself implements {@code TileFactory}. If this is not the case,
-     * the custom tile factory has to implement this.
+     * The default method assumes that the tile itself implements {@code CandidateTile}. If this is not the case,
+     * the custom candidate tile has to implement this.
      */
     default Tile<?> createInstance() {
         if (!(this instanceof Tile<?> tile)) {
-            throw new RuntimeException("TileFactory " + getClass().getSimpleName()  + " is not a tile. In that case, implement createInstance yourself.");
+            throw new RuntimeException(getClass().getSimpleName()  + " does not inherit from Tile<?>. In that case, implement createInstance yourself.");
         }
 
         try {

--- a/integrations/beast3/java/src/main/java/tiling/EvaluateTiles.java
+++ b/integrations/beast3/java/src/main/java/tiling/EvaluateTiles.java
@@ -179,6 +179,18 @@ public class EvaluateTiles implements AstVisitor<Void, Void, Void> {
                 );
             } catch (FailedTilingAttempt.Irrelevant e) {
                 continue;
+            } catch (FailedTilingAttempt.RejectedCascade e) {
+                if (e.getOtherNode() == node) {
+                    // the other node points to the node itself. This can sometimes happen due to template matching
+                    // or bugs in TileInput fields
+
+                    // we log this error as irrelevant as otherwise we might have cycles leading to stack overflows later
+                    failures.add(new FailedTilingAttempt.Irrelevant());
+                } else {
+                    failures.add(e);
+                }
+
+                continue;
             } catch (FailedTilingAttempt e) {
                 // this tile is relevant but couldn't be applied
                 failures.add(e);

--- a/integrations/beast3/java/src/main/java/tiling/EvaluateTiles.java
+++ b/integrations/beast3/java/src/main/java/tiling/EvaluateTiles.java
@@ -15,7 +15,7 @@ import java.util.*;
  */
 public class EvaluateTiles implements AstVisitor<Void, Void, Void> {
 
-    private final List<Tile<?>> tiles;
+    private final List<TileFactory> candidateTiles;
     private final List<Tile<?>> operatorTiles;
 
     private List<Tile<?>> bestTiles;
@@ -40,8 +40,8 @@ public class EvaluateTiles implements AstVisitor<Void, Void, Void> {
     // sentinel depth for nodes that tiled successfully (they act as dead-ends in the cascade DAG)
     private static final int DEPTH_SUCCEEDED = Integer.MIN_VALUE;
 
-    public EvaluateTiles(List<Tile<?>> tiles, List<Tile<?>> operatorTiles, VariableResolver variableResolver, StochasticityResolver stochasticityResolver) {
-        this.tiles = tiles;
+    public EvaluateTiles(List<TileFactory> candidateTiles, List<Tile<?>> operatorTiles, VariableResolver variableResolver, StochasticityResolver stochasticityResolver) {
+        this.candidateTiles = candidateTiles;
         this.operatorTiles = operatorTiles;
         this.variableResolver = variableResolver;
         this.stochasticityResolver = stochasticityResolver;
@@ -171,7 +171,7 @@ public class EvaluateTiles implements AstVisitor<Void, Void, Void> {
 
         // we go through all tiles and try to apply them
 
-        for (Tile<?> tile : this.tiles) {
+        for (TileFactory tile : this.candidateTiles) {
             Set<Tile<?>> evaluatedTiles;
             try {
                 evaluatedTiles = tile.tryToTile(

--- a/integrations/beast3/java/src/main/java/tiling/EvaluateTiles.java
+++ b/integrations/beast3/java/src/main/java/tiling/EvaluateTiles.java
@@ -15,7 +15,7 @@ import java.util.*;
  */
 public class EvaluateTiles implements AstVisitor<Void, Void, Void> {
 
-    private final List<TileFactory> candidateTiles;
+    private final List<CandidateTile> candidateTiles;
     private final List<Tile<?>> operatorTiles;
 
     private List<Tile<?>> bestTiles;
@@ -40,7 +40,7 @@ public class EvaluateTiles implements AstVisitor<Void, Void, Void> {
     // sentinel depth for nodes that tiled successfully (they act as dead-ends in the cascade DAG)
     private static final int DEPTH_SUCCEEDED = Integer.MIN_VALUE;
 
-    public EvaluateTiles(List<TileFactory> candidateTiles, List<Tile<?>> operatorTiles, VariableResolver variableResolver, StochasticityResolver stochasticityResolver) {
+    public EvaluateTiles(List<CandidateTile> candidateTiles, List<Tile<?>> operatorTiles, VariableResolver variableResolver, StochasticityResolver stochasticityResolver) {
         this.candidateTiles = candidateTiles;
         this.operatorTiles = operatorTiles;
         this.variableResolver = variableResolver;
@@ -171,7 +171,7 @@ public class EvaluateTiles implements AstVisitor<Void, Void, Void> {
 
         // we go through all tiles and try to apply them
 
-        for (TileFactory tile : this.candidateTiles) {
+        for (CandidateTile tile : this.candidateTiles) {
             Set<Tile<?>> evaluatedTiles;
             try {
                 evaluatedTiles = tile.tryToTile(

--- a/integrations/beast3/java/src/main/java/tiling/FailedTilingAttempt.java
+++ b/integrations/beast3/java/src/main/java/tiling/FailedTilingAttempt.java
@@ -27,20 +27,15 @@ public abstract class FailedTilingAttempt extends Throwable {
     /** This error indicates that the tile is relevant but failed due to an incompatibility at the tile boundary. */
     public static class RejectedBoundary extends FailedTilingAttempt {
         private final String reason;
-        private final AstNode otherNode;
 
-        public RejectedBoundary(String reason, AstNode otherNode) {
+        public RejectedBoundary(String reason) {
             this.reason = reason;
-            this.otherNode = otherNode;
         }
 
         public String getReason() {
             return reason;
         }
 
-        public AstNode getOtherNode() {
-            return otherNode;
-        }
     }
 
     /** This error indicates that the tile is relevant but failed due a missing tile at the interface. */

--- a/integrations/beast3/java/src/main/java/tiling/Tile.java
+++ b/integrations/beast3/java/src/main/java/tiling/Tile.java
@@ -1,34 +1,21 @@
 package tiling;
 
 import beastconfig.BEASTState;
-import org.phylospec.Utils;
 import org.phylospec.ast.AstNode;
 import org.phylospec.ast.Expr;
-import org.phylospec.typeresolver.Stochasticity;
-import org.phylospec.typeresolver.StochasticityResolver;
-import org.phylospec.typeresolver.VariableResolver;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
 
+/**
+ * A tile covers a subgraph of the PhyloSpec AST rooted at a root node and describes how to turn ("apply") this
+ * subgraph into BEAST objects.
+ */
 public abstract class Tile<T> {
-    /* methods to find a tiling */
 
-    /**
-     * Returns the default priority of these tiles. Can be overridden by custom tiles.
-     */
-    public TilePriority getPriority() {
-        return TilePriority.DEFAULT;
-    }
-
-    /**
-     * Returns the different stochasticity levels which the root of the AST subgraph covered by the tile can have.
-     */
-    protected Set<Stochasticity> getCompatibleStochasticities() {
-        return EnumSet.allOf(Stochasticity.class);
-    }
+    /* methods to evaluate a tiling */
 
     /**
      * Returns the {@code TypeToken<?>} produced when by a successful application of this tile.
@@ -44,16 +31,6 @@ public abstract class Tile<T> {
             throw new IllegalArgumentException("Tile " + this.getClass() + " has no return type parameter. Either specify the type in the type signature of the inheriting class, or override the getTypeToken method.");
         }
     }
-
-    /**
-     * Tries to tile this tile to the AST subgraph starting with 'node'. Has to be overridden by custom tiles.
-     */
-    public abstract Set<Tile<?>> tryToTile(
-            AstNode node, Map<AstNode,
-            Set<Tile<?>>> inputTiles,
-            VariableResolver variableResolver,
-            StochasticityResolver stochasticityResolver
-    ) throws FailedTilingAttempt;
 
     /**
      * Recursively walks this tile's wired sub-tiles and verifies that no AstNode is committed
@@ -132,53 +109,6 @@ public abstract class Tile<T> {
             }
         }
         return inputs;
-    }
-
-    /**
-     * Creates wired up fresh tiles for the given inputs and their compatible input tiles.
-     */
-    protected Set<Tile<?>> getWiredUpTiles(
-            List<TileInput<?>> tileInputs,
-            List<Set<Tile<?>>> compatibleInputTiles,
-            AstNode rootNode
-    ) {
-        Set<Tile<?>> wiredUpTiles = new HashSet<>();
-
-        Utils.visitCombinations(
-                compatibleInputTiles,
-                inputs -> {
-                    Tile<?> wiredUpTile = this.createInstance();
-
-                    // get TileInput fields from fresh instance
-
-                    Map<String, TileInput<?>> freshInputsByKey = new HashMap<>();
-                    for (TileInput<?> freshInput : wiredUpTile.getTileInputs()) {
-                        freshInputsByKey.put(freshInput.getKey(), freshInput);
-                    }
-
-                    // wire each input tile and accumulate weight
-
-                    int totalWeight = this.getPriority().getWeight();
-                    for (int i = 0; i < tileInputs.size(); i++) {
-                        Tile<?> inputTile = inputs.get(i);
-                        String tileInputKey = tileInputs.get(i).getKey();
-
-                        TileInput<?> freshInputTile = freshInputsByKey.get(tileInputKey);
-                        freshInputTile.setTile(inputTile);
-
-                        totalWeight += inputTile.getWeight();
-                    }
-
-                    wiredUpTile.setWeight(totalWeight);
-                    wiredUpTile.setRootNode(rootNode);
-
-                    if (!wiredUpTile.isInconsistent(new IdentityHashMap<>())) {
-                        wiredUpTiles.add(wiredUpTile);
-                    }
-                }
-        );
-
-        return wiredUpTiles;
     }
 
     /** methods to apply a tiling */
@@ -278,17 +208,6 @@ public abstract class Tile<T> {
     }
 
     /* helper */
-
-    /**
-     * Creates a new instance of this tile.
-     */
-    protected Tile<?> createInstance() {
-        try {
-            return this.getClass().getDeclaredConstructor().newInstance();
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException("Tile " + getClass().getSimpleName() + " has no public no-arg constructor", e);
-        }
-    }
 
     /**
      * Constructs an ID consisting of the given prefix, postfix, and index variables.

--- a/integrations/beast3/java/src/main/java/tiling/TileFactory.java
+++ b/integrations/beast3/java/src/main/java/tiling/TileFactory.java
@@ -1,0 +1,105 @@
+package tiling;
+
+import org.phylospec.Utils;
+import org.phylospec.ast.AstNode;
+import org.phylospec.typeresolver.Stochasticity;
+import org.phylospec.typeresolver.StochasticityResolver;
+import org.phylospec.typeresolver.VariableResolver;
+
+import java.util.*;
+
+/**
+ * This interface provides methods to construct tiles for a subgraph of the PhyloSpec AST.
+ */
+public interface TileFactory {
+
+    /**
+     * Tries to tile this tile to the AST subgraph starting with 'node'. Has to be overridden by custom tile factories.
+     * Returns a set of the possible tilings.
+     */
+    Set<Tile<?>> tryToTile(
+            AstNode node,
+            Map<AstNode, Set<Tile<?>>> inputTiles,
+            VariableResolver variableResolver,
+            StochasticityResolver stochasticityResolver
+    ) throws FailedTilingAttempt;
+
+    /**
+     * Creates wired up fresh tiles for the given inputs and their compatible input tiles.
+     */
+    default Set<Tile<?>> getWiredUpTiles(
+            List<TileInput<?>> tileInputs,
+            List<Set<Tile<?>>> compatibleInputTiles,
+            AstNode rootNode
+    ) {
+        Set<Tile<?>> wiredUpTiles = new HashSet<>();
+
+        Utils.visitCombinations(
+                compatibleInputTiles,
+                inputs -> {
+                    Tile<?> wiredUpTile = this.createInstance();
+
+                    // get TileInput fields from fresh instance
+
+                    Map<String, TileInput<?>> freshInputsByKey = new HashMap<>();
+                    for (TileInput<?> freshInput : wiredUpTile.getTileInputs()) {
+                        freshInputsByKey.put(freshInput.getKey(), freshInput);
+                    }
+
+                    // wire each input tile and accumulate weight
+
+                    int totalWeight = this.getPriority().getWeight();
+                    for (int i = 0; i < tileInputs.size(); i++) {
+                        Tile<?> inputTile = inputs.get(i);
+                        String tileInputKey = tileInputs.get(i).getKey();
+
+                        TileInput<?> freshInputTile = freshInputsByKey.get(tileInputKey);
+                        freshInputTile.setTile(inputTile);
+
+                        totalWeight += inputTile.getWeight();
+                    }
+
+                    wiredUpTile.setWeight(totalWeight);
+                    wiredUpTile.setRootNode(rootNode);
+
+                    if (!wiredUpTile.isInconsistent(new IdentityHashMap<>())) {
+                        wiredUpTiles.add(wiredUpTile);
+                    }
+                }
+        );
+
+        return wiredUpTiles;
+    }
+
+    /**
+     * Returns the different stochasticity levels which the root of the AST subgraph covered by the tile can have.
+     */
+    default Set<Stochasticity> getCompatibleStochasticities() {
+        return EnumSet.allOf(Stochasticity.class);
+    }
+
+    /**
+     * Returns the default priority of these tiles. Can be overridden by custom tiles.
+     */
+    default TilePriority getPriority() {
+        return TilePriority.DEFAULT;
+    }
+
+    /**
+     * Creates a new instance of the corresponding tile.
+     * The default method assumes that the tile itself implements {@code TileFactory}. If this is not the case,
+     * the custom tile factory has to implement this.
+     */
+    default Tile<?> createInstance() {
+        if (!(this instanceof Tile<?> tile)) {
+            throw new RuntimeException("TileFactory " + getClass().getSimpleName()  + " is not a tile. In that case, implement createInstance yourself.");
+        }
+
+        try {
+            return tile.getClass().getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Tile " + getClass().getSimpleName() + " has no public no-arg constructor", e);
+        }
+    }
+
+}

--- a/integrations/beast3/java/src/main/java/tiling/TileInput.java
+++ b/integrations/beast3/java/src/main/java/tiling/TileInput.java
@@ -59,8 +59,7 @@ public abstract class TileInput<T> {
         Stochasticity stochasticity = stochasticityResolver.getStochasticity(inputAstNode);
         if (!this.acceptedStochasticities.contains(stochasticity)) {
             throw new FailedTilingAttempt.RejectedBoundary(
-                    Stochasticity.getErrorMessage("BEAST 2.8", this.getKey(), stochasticity, this.acceptedStochasticities),
-                    inputAstNode
+                    Stochasticity.getErrorMessage("BEAST 2.8", this.getKey(), stochasticity, this.acceptedStochasticities)
             );
         }
 


### PR DESCRIPTION
These commits separate the tiling concern in the `Tile` class into two focused abstractions:
                                                                                                                                                                        
- `CandidateTile` (new interface) — handles tile construction: tryToTile, getWiredUpTiles, createInstance, and priority/stochasticity metadata. Previously this logic lived in Tile.                                                                                                                                                        

- `Tile` now focuses solely on the result of a successful tiling: applying it, its weight, and consistency checks.
                                                                                                       
The refactor removes ~90 lines from Tile.java into the new CandidateTile.java, keeping each class responsible for one stage of the tiling pipeline. Tile implementations (AstNodeTile, GeneratorTile, TemplateTile, etc.) and EvaluateTiles are updated to use the new split accordingly.