### PR TITLE
Wire up BEAST X dependency and add JC69 tile

### DIFF
--- a/integrations/beastx/README.md
+++ b/integrations/beastx/README.md
@@ -1,0 +1,35 @@
+# PhyloSpec BEAST X Integration
+
+PhyloSpec parser and runner for [BEAST X](https://github.com/beast-dev/beast-mcmc).
+
+## Setup
+
+BEAST X is not published to a public Maven repository, so its jar must be
+installed into your local Maven repository before you can build this module.
+
+From the repository root:
+
+```sh
+./integrations/beastx/install-beast-mcmc.sh
+```
+
+The script downloads the official BEAST X release tgz from GitHub, extracts the
+bundled fat jar (`beast.jar`, ~12 MB, includes JEBL, JAM, JDOM, commons-math,
+colt, BEAGLE, EJML, MTJ), and runs `mvn install:install-file` to register it as
+`dr:beast-mcmc:<version>` in `~/.m2/repository`.
+
+The pinned version lives at the top of the script (`BEAST_MCMC_VERSION`). When
+it bumps, every developer reruns the script.
+
+### Requirements
+
+- `bash`, `curl`, `tar` (Mac/Linux: built in; Windows: WSL or Git Bash)
+- `mvn` on `PATH`
+
+## Build
+
+Once BEAST X is installed locally:
+
+```sh
+mvn -pl integrations/beastx/java -am compile
+```

--- a/integrations/beastx/install-beast-mcmc.sh
+++ b/integrations/beastx/install-beast-mcmc.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Downloads the BEAST X release and installs the bundled beast.jar into the
+# local Maven repository as dr:beast-mcmc:<version>. Run once after cloning
+# (or whenever BEAST_MCMC_VERSION bumps).
+
+set -euo pipefail
+
+BEAST_MCMC_VERSION="10.5.0"
+URL="https://github.com/beast-dev/beast-mcmc/releases/download/v${BEAST_MCMC_VERSION}/BEAST_X_v${BEAST_MCMC_VERSION}.tgz"
+JAR_IN_TGZ="BEASTv${BEAST_MCMC_VERSION}/lib/beast.jar"
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "Downloading BEAST X v${BEAST_MCMC_VERSION}..."
+curl -fsSL -o "$WORK_DIR/beastx.tgz" "$URL"
+
+echo "Extracting beast.jar..."
+tar -xzf "$WORK_DIR/beastx.tgz" -C "$WORK_DIR" "$JAR_IN_TGZ"
+
+echo "Installing dr:beast-mcmc:${BEAST_MCMC_VERSION} to local Maven repository..."
+mvn install:install-file \
+  -Dfile="$WORK_DIR/$JAR_IN_TGZ" \
+  -DgroupId=dr \
+  -DartifactId=beast-mcmc \
+  -Dversion="${BEAST_MCMC_VERSION}" \
+  -Dpackaging=jar
+
+echo
+echo "Done. dr:beast-mcmc:${BEAST_MCMC_VERSION} is now available locally."

--- a/integrations/beastx/java/pom.xml
+++ b/integrations/beastx/java/pom.xml
@@ -26,6 +26,14 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- BEAST X. Not on Maven Central; install locally first via
+             integrations/beastx/install-beast-mcmc.sh (see README). -->
+        <dependency>
+            <groupId>dr</groupId>
+            <artifactId>beast-mcmc</artifactId>
+            <version>10.5.0</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/integrations/beastx/java/src/main/java/tiles/BeastXCoreTileLibrary.java
+++ b/integrations/beastx/java/src/main/java/tiles/BeastXCoreTileLibrary.java
@@ -2,6 +2,7 @@ package tiles;
 
 import org.phylospec.tiling.TileLibrary;
 import org.phylospec.tiling.tiles.CandidateTile;
+import tiles.substitutionmodels.JC69Tile;
 import tiling.BeastXState;
 
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ public class BeastXCoreTileLibrary extends TileLibrary<BeastXState> {
     public List<CandidateTile<BeastXState>> getTiles() {
         List<CandidateTile<BeastXState>> tiles = new ArrayList<>();
 
-        // TODO: add tiles
+        tiles.add(new JC69Tile());
 
         return tiles;
     }

--- a/integrations/beastx/java/src/main/java/tiles/substitutionmodels/JC69Tile.java
+++ b/integrations/beastx/java/src/main/java/tiles/substitutionmodels/JC69Tile.java
@@ -1,0 +1,27 @@
+package tiles.substitutionmodels;
+
+import dr.evolution.datatype.Nucleotides;
+import dr.evomodel.substmodel.FrequencyModel;
+import dr.evomodel.substmodel.nucleotide.HKY;
+import org.phylospec.ast.Expr;
+import org.phylospec.tiling.tiles.GeneratorTile;
+import tiling.BeastXState;
+
+import java.util.IdentityHashMap;
+
+public class JC69Tile extends GeneratorTile<HKY, BeastXState> {
+
+    @Override
+    public String getPhyloSpecGeneratorName() {
+        return "jc69";
+    }
+
+    @Override
+    public HKY applyTile(BeastXState beastState, IdentityHashMap<Expr.Variable, Integer> indexVariables) {
+        FrequencyModel frequencies = new FrequencyModel(
+                Nucleotides.INSTANCE,
+                new double[]{0.25, 0.25, 0.25, 0.25}
+        );
+        return new HKY(1.0, frequencies);
+    }
+}

--- a/integrations/beastx/java/src/test/java/tiles/substitutionmodels/JC69TileTest.java
+++ b/integrations/beastx/java/src/test/java/tiles/substitutionmodels/JC69TileTest.java
@@ -1,0 +1,32 @@
+package tiles.substitutionmodels;
+
+import dr.evomodel.substmodel.nucleotide.HKY;
+import org.junit.jupiter.api.Test;
+import tiling.BeastXState;
+
+import java.util.IdentityHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class JC69TileTest {
+
+    @Test
+    void appliesToProduceJC69ConfiguredHKY() {
+        JC69Tile tile = new JC69Tile();
+        HKY model = tile.applyTile(new BeastXState("test"), new IdentityHashMap<>());
+
+        assertNotNull(model);
+        assertEquals(1.0, model.getKappa(), 1e-9);
+        double[] freqs = model.getFrequencyModel().getFrequencies();
+        assertEquals(4, freqs.length);
+        for (double f : freqs) {
+            assertEquals(0.25, f, 1e-9);
+        }
+    }
+
+    @Test
+    void generatorNameIsJc69() {
+        assertEquals("jc69", new JC69Tile().getPhyloSpecGeneratorName());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `install-beast-mcmc.sh` + README that download the BEAST X v10.5.0 release tgz and register the bundled fat `beast.jar` as `dr:beast-mcmc:10.5.0` in the local Maven repo. `integrations/beastx/java/pom.xml` now depends on that artifact.
- Ports `JC69Tile` from the BEAST 2 integration. BEAST X has no dedicated `JukesCantor` class, so the tile builds `HKY` with kappa=1.0 and equal nucleotide frequencies. Registered in `BeastXCoreTileLibrary`.
- Adds a JUnit test that calls `JC69Tile.applyTile(...)` and asserts on the resulting `HKY` — exercises the BEAST X classpath at runtime.

## Test plan
- [x] Run `./integrations/beastx/install-beast-mcmc.sh` on a fresh clone
- [x] `mvn -pl integrations/beastx/java -am compile` succeeds
- [x] `mvn -pl integrations/beastx/java test -Dtest=JC69TileTest` passes (2/2)

## Notes
- Base is `beastx-parser`, not `main`.
- Pre-existing failures in `phylospec-core` `RevConverterTest` (`The function nexus does not exist`) on the `beastx-parser` branch block a top-level `mvn test`. Unrelated to this change but worth flagging.
