### PR TITLE
Fix unsound Real * Real result type in type resolver

### DIFF
--- a/core/java/src/main/java/org/phylospec/typeresolver/TypeResolver.java
+++ b/core/java/src/main/java/org/phylospec/typeresolver/TypeResolver.java
@@ -671,7 +671,7 @@ public class TypeResolver implements AstVisitor<Set<ResolvedType>, Set<ResolvedT
                 new TypeMatcher.Rule(TokenType.STAR, "PositiveInteger", "PositiveReal", "PositiveReal"),
                 new TypeMatcher.Rule(TokenType.STAR, "PositiveReal", "PositiveInteger", "PositiveReal"),
                 new TypeMatcher.Rule(TokenType.STAR, "NonNegativeReal", "NonNegativeReal", "NonNegativeReal"),
-                new TypeMatcher.Rule(TokenType.STAR, "Real", "Real", "NonNegativeReal"),
+                new TypeMatcher.Rule(TokenType.STAR, "Real", "Real", "Real"),
                 new TypeMatcher.Rule(TokenType.STAR, "Integer", "Integer", "Integer"),
                 new TypeMatcher.Rule(TokenType.STAR, "Integer", "Real", "Real"),
                 new TypeMatcher.Rule(TokenType.STAR, "Real", "Integer", "Real"),

--- a/core/java/src/test/java/org/phylospec/parser/expressions/realMultiplication.phylospec
+++ b/core/java/src/test/java/org/phylospec/parser/expressions/realMultiplication.phylospec
@@ -1,0 +1,13 @@
+Real a = -2.0
+Real b = 3.0
+NonNegativeReal c = a * b
+
+// EXPECT AST
+// (AS Real a (- 2.0))
+// (AS Real b 3.0)
+// (AS NonNegativeReal c (* a b))
+// EXPECT AST
+
+// EXPECT TYPE_ERRORS
+// Expression of type `Real` cannot be assigned to variable `c` of type `NonNegativeReal`. Change the type of the variable to `Real`, or change what you assign to it.
+// EXPECT TYPE_ERRORS


### PR DESCRIPTION
## Summary

The binary-operator rule table in `TypeResolver.visitBinary` typed `Real * Real` as `NonNegativeReal`:

```java
new TypeMatcher.Rule(TokenType.STAR, "Real", "Real", "NonNegativeReal"),
```

That is unsound. The product of two reals is negative whenever the operands have opposite signs (e.g. `-2.0 * 3.0 = -6.0`), so the static type claimed a non-negativity that the value does not have. A consumer trusting the resolved static type (and skipping the construction-time `isValid` guard) would accept a negative `NonNegativeReal`.

It was also inconsistent with its neighbours: `Real * Integer` and `Integer * Real` both widen to `Real`, while `Real * Real` claimed `NonNegativeReal`.

## Fix

Multiplication is not sign-closed over the reals, so the strongest sound result is `Real`:

```java
new TypeMatcher.Rule(TokenType.STAR, "Real", "Real", "Real"),
```

The `PositiveReal * PositiveReal` and `NonNegativeReal * NonNegativeReal` rules above it still preserve the refinement where the sign is provable.

## Test

Adds `expressions/realMultiplication.phylospec`, which asserts that a `Real * Real` product cannot be assigned to a `NonNegativeReal` variable. With the old rule the assignment type-checked (no error) and the test would fail; with the fix it produces the expected assignment type error.

`ScriptFilesParserTest` and `ScriptFilesTypesTest` both pass (44 tests each, 0 failures).