### PR TITLE
Minor Improvements to the Core

### DIFF
--- a/core/java/src/main/java/org/phylospec/lexer/Lexer.java
+++ b/core/java/src/main/java/org/phylospec/lexer/Lexer.java
@@ -360,7 +360,6 @@ public class Lexer {
     private void comment() {
         // this is a comment, it goes until the end of the line
         while (peek() != '\n' && !isAtEnd()) advance();
-        addToken(TokenType.COMMENT, source.substring(start + 2, current));
     }
 
     /* general helper methods */

--- a/core/java/src/main/java/org/phylospec/lexer/TokenType.java
+++ b/core/java/src/main/java/org/phylospec/lexer/TokenType.java
@@ -50,10 +50,7 @@ public enum TokenType {
 
     // terminators
     EOL,
-    EOF,
-
-    // comment
-    COMMENT;
+    EOF;
 
     public static String getLexeme(TokenType token) {
         return switch (token) {

--- a/core/java/src/main/java/org/phylospec/parser/Parser.java
+++ b/core/java/src/main/java/org/phylospec/parser/Parser.java
@@ -45,7 +45,7 @@ public class Parser {
     private Range currentBlockRange = null;
 
     private final Map<Token, AstNode> tokenAstNodeMap;
-    private final Map<AstNode, Range> astNodeRanges;
+    private final IdentityHashMap<AstNode, Range> astNodeRanges;
     private final LinkedList<Integer> astNodeStartPositions;
 
     private final List<ErrorEventListener> eventListeners;
@@ -59,7 +59,7 @@ public class Parser {
         this.tokens = tokens;
         this.eventListeners = new ArrayList<>();
         this.tokenAstNodeMap = new HashMap<>();
-        this.astNodeRanges = new HashMap<>();
+        this.astNodeRanges = new IdentityHashMap<>();
         this.astNodeStartPositions = new LinkedList<>();
     }
 

--- a/core/java/src/main/java/org/phylospec/parser/Parser.java
+++ b/core/java/src/main/java/org/phylospec/parser/Parser.java
@@ -208,14 +208,9 @@ public class Parser {
                     "Block not closed.",
                     "You are starting a '"
                             + blockName
-                            + "' without closing the '"
+                            + "' block without closing the '"
                             + currentBlock.toString()
-                            + "' block. End the block with curly braces first.",
-                    List.of(
-                            currentBlock.toString()
-                                    + "{\n\t\t...\t\n}\n\t"
-                                    + blockName
-                                    + "\n\t\t...\n\t}"));
+                            + "' block. End the block with curly braces first.");
         }
 
         currentBlockRange = previous().range;

--- a/core/java/src/main/java/org/phylospec/parser/Parser.java
+++ b/core/java/src/main/java/org/phylospec/parser/Parser.java
@@ -313,12 +313,27 @@ public class Parser {
 
         AstType type = type();
 
+        // we check for the special case where someone forgot to specify a type (e.g. "x = 10") and
+        // give a helpful message
+
+        Token currentToken = peek();
+        if (currentToken != null
+                && (currentToken.type == TokenType.EQUAL || currentToken.type == TokenType.TILDE)) {
+            throw new Error(
+                    currentToken.range,
+                    "Missing type.",
+                    "You have to specify the type of the variable. Some possible types are 'Alignment', 'Tree', 'Real', 'Rate', or 'Vector<Rate>'.",
+                    List.of("Tree " + type.name + " " + currentToken.lexeme + " ..."));
+        }
+
+        // consume the variable name
+
         Token nameToken =
                 consume(
                         TokenType.IDENTIFIER,
                         "Invalid variable name.",
                         "Choose a variable name which starts with a letter and only consists of letters and digits.",
-                        List.of("Real x = 10"));
+                        List.of("Real number = 10"));
 
         // check if this is an indexed statement and parse the index if needed
 

--- a/core/java/src/main/java/org/phylospec/parser/Parser.java
+++ b/core/java/src/main/java/org/phylospec/parser/Parser.java
@@ -477,10 +477,16 @@ public class Parser {
         Token typeNameToken =
                 consume(
                         TokenType.IDENTIFIER,
-                        "Invalid variable type.",
+                        "Invalid type name.",
                         "Type names can only consist of letters.");
 
         if (match(TokenType.LESS)) {
+            // handle the special case of an empty generic (like "Real<>")
+            if (check(TokenType.GREATER)) {
+                advance();
+                return remember(new AstType.Atomic(typeNameToken.lexeme));
+            }
+
             List<AstType> innerTypes = new ArrayList<>();
             innerTypes.add(type());
 

--- a/core/java/src/main/java/org/phylospec/tiling/EvaluateTiles.java
+++ b/core/java/src/main/java/org/phylospec/tiling/EvaluateTiles.java
@@ -155,7 +155,7 @@ public class EvaluateTiles<S> implements AstVisitor<Void, Void, Void> {
             // no consistent tiling found
             // this is very rare
             throw new TileApplicationError(
-                    "Unsupported operation.", "Your model is not supported by BEAST 2.8.");
+                    "Unsupported operation.", "Your model is not supported by your engine.");
         }
 
         this.bestTiles = bestTiles;

--- a/core/java/src/main/java/org/phylospec/typeresolver/ResolvedType.java
+++ b/core/java/src/main/java/org/phylospec/typeresolver/ResolvedType.java
@@ -90,8 +90,7 @@ public class ResolvedType {
                     "Are you looking for '" + componentResolver.findClosestType(typeString) + "'?");
         }
 
-        if (!allowUnresolvedTypeParameter
-                && typeParameters.size() != typeComponent.getTypeParameters().size()) {
+        if (typeParameters.size() != typeComponent.getTypeParameters().size()) {
             throw new TypeError(
                     "The type '"
                             + typeString
@@ -100,7 +99,9 @@ public class ResolvedType {
                             + " type parameters, but you provided "
                             + typeParameters.size()
                             + ".",
-                    "Provide exactly " + typeParameters.size() + " type parameters.");
+                    "Provide exactly "
+                            + typeComponent.getTypeParameters().size()
+                            + " type parameters.");
         }
 
         Map<String, Set<ResolvedType>> typeParameterMap = new HashMap<>();

--- a/core/java/src/main/java/org/phylospec/typeresolver/TypeResolver.java
+++ b/core/java/src/main/java/org/phylospec/typeresolver/TypeResolver.java
@@ -449,6 +449,17 @@ public class TypeResolver
         // test if the observed value can be assigned to the generated value
 
         if (!TypeUtils.canBeAssignedTo(observationTypeSet, generatedTypeSet, componentResolver)) {
+            // we check if this could work with an "observed between" statement
+            if (TypeUtils.canBeAssignedTo(
+                    observationTypeSet,
+                    ResolvedType.fromString("phylospec.types.Vector", componentResolver, true),
+                    componentResolver)) {
+                throw new TypeError(
+                        observedAs,
+                        "Wrong observation type.",
+                        "You might want to use 'observed between' instead of 'observed as'.");
+            }
+
             throw new TypeError(
                     observedAs,
                     "Wrong observation type.",

--- a/core/java/src/main/java/org/phylospec/typeresolver/TypeResolver.java
+++ b/core/java/src/main/java/org/phylospec/typeresolver/TypeResolver.java
@@ -128,7 +128,39 @@ public class TypeResolver
 
         if (!TypeUtils.canBeAssignedTo(
                 resolvedExpressionTypeSet, resolvedVariableTypeSet, componentResolver)) {
-            // TODO: check if distribution and give hint to use ~
+            // expression cannot be assigned to this variable
+            // we check if a draw would fix the problem and raise a more helpful message in that
+            // case
+
+            Set<ResolvedType> resolvedDistributionTypeSet = new HashSet<>();
+            for (ResolvedType expressionType : resolvedExpressionTypeSet) {
+                TypeUtils.visitTypeAndParents(
+                        expressionType,
+                        x -> {
+                            if (x.getName().equals("phylospec.types.Distribution")) {
+                                resolvedDistributionTypeSet.add(x.getParameterTypes().get("T"));
+                            }
+                            return TypeUtils.Visitor.CONTINUE;
+                        },
+                        componentResolver);
+            }
+            if (TypeUtils.canBeAssignedTo(
+                    resolvedDistributionTypeSet, resolvedVariableTypeSet, componentResolver)) {
+                throw new TypeError(
+                        stmt,
+                        "Expression of type `"
+                                + printType(resolvedExpressionTypeSet)
+                                + "` cannot be assigned to variable `"
+                                + stmt.name
+                                + "` of type `"
+                                + printType(resolvedVariableTypeSet)
+                                + "`.",
+                        "You probably want to use '~' to draw the variable from the distribution.",
+                        List.of(stmt.type.name + " " + stmt.name + " ~ ..."));
+            }
+
+            // it would not work even with a draw
+
             throw new TypeError(
                     stmt,
                     "Expression of type `"
@@ -207,7 +239,8 @@ public class TypeResolver
             throw new TypeError(
                     stmt,
                     "Expression after `~' is not a distribution.",
-                    "After '~', you always need to provide a distribution. Do you want use `=` instead?");
+                    "After '~', you always need to provide a distribution. Do you want use `=` instead?",
+                    List.of(stmt.type.name + " " + stmt.name + " = ..."));
         }
 
         if (!TypeUtils.canBeAssignedTo(
@@ -399,7 +432,6 @@ public class TypeResolver
                 // this is not a distribution type directly
                 // it could still be a random variable though
                 generatedTypeSet.add(generatedDistType);
-                continue;
             } else {
                 ResolvedType generatedType = recoveredDistributionType.getParameterTypes().get("T");
                 if (generatedType == null) continue;

--- a/core/java/src/main/java/org/phylospec/typeresolver/TypeResolver.java
+++ b/core/java/src/main/java/org/phylospec/typeresolver/TypeResolver.java
@@ -173,6 +173,8 @@ public class TypeResolver
             }
         }
 
+        enforceUniqueness(stmt.name, stmt);
+
         remember(stmt.name, resolvedVariableTypeSet);
         return remember(stmt, resolvedVariableTypeSet);
     }
@@ -254,6 +256,8 @@ public class TypeResolver
             }
         }
 
+        enforceUniqueness(stmt.name, stmt);
+
         remember(stmt.name, resolvedVariableTypeSet);
         return remember(stmt, resolvedVariableTypeSet);
     }
@@ -334,6 +338,7 @@ public class TypeResolver
                     if (indexVarType != null) indexVarTypeSet.add(indexVarType);
                 }
 
+                enforceUniqueness(indexVar.variableName, indexVar);
                 remember(indexVar.variableName, indexVarTypeSet);
             }
 
@@ -1192,6 +1197,18 @@ public class TypeResolver
     private Set<ResolvedType> remember(String variableName, Set<ResolvedType> resolvedTypeSet) {
         scopedVariableTypes.getFirst().put(variableName, resolvedTypeSet);
         return resolvedTypeSet;
+    }
+
+    private void enforceUniqueness(String variableName, AstNode astNode) {
+        if (scopedVariableTypes.getFirst().containsKey(variableName)) {
+            throw new TypeError(
+                    astNode,
+                    "Duplicate variable name.",
+                    "You have already used the variable name '"
+                            + variableName
+                            + "' before. Use another name instead.",
+                    List.of());
+        }
     }
 
     /**

--- a/core/java/src/test/java/org/phylospec/FuzzingUtils.java
+++ b/core/java/src/test/java/org/phylospec/FuzzingUtils.java
@@ -1,8 +1,17 @@
 package org.phylospec;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FuzzingUtils {
+    // matches either a run of whitespace, a run of word characters, or a single
+    // other character, so that concatenating all matches reproduces the input exactly
+    private static final Pattern TOKEN_PATTERN = Pattern.compile("\\s+|\\w+|[^\\w\\s]");
+
     public static String randomString(Random r, int length, int minChar, int maxChar) {
         StringBuilder sb = new StringBuilder(length);
         int range = maxChar - minChar + 1;
@@ -57,5 +66,94 @@ public class FuzzingUtils {
             }
         }
         return sb.toString();
+    }
+
+    /* token-level mutations, using a lightweight regex tokeniser */
+
+    // splits a string into whitespace and non-whitespace pieces, in order, so that
+    // joining the returned list reproduces the original string exactly
+    public static List<String> splitTokens(String input) {
+        List<String> pieces = new ArrayList<>();
+        Matcher m = TOKEN_PATTERN.matcher(input);
+        while (m.find()) {
+            pieces.add(m.group());
+        }
+        return pieces;
+    }
+
+    // rejoins the output of splitTokens back into a single string
+    public static String joinTokens(List<String> pieces) {
+        StringBuilder sb = new StringBuilder();
+        for (String piece : pieces) {
+            sb.append(piece);
+        }
+        return sb.toString();
+    }
+
+    // returns the indices of the non-whitespace pieces in a tokenised string
+    private static List<Integer> nonWhitespaceIndices(List<String> pieces) {
+        List<Integer> indices = new ArrayList<>();
+        for (int i = 0; i < pieces.size(); i++) {
+            if (!pieces.get(i).isBlank()) {
+                indices.add(i);
+            }
+        }
+        return indices;
+    }
+
+    // deletes one random non-whitespace token, leaving surrounding whitespace untouched
+    public static String deleteRandomToken(Random r, String input) {
+        List<String> pieces = splitTokens(input);
+        List<Integer> indices = nonWhitespaceIndices(pieces);
+        if (indices.isEmpty()) return input;
+
+        pieces.remove((int) indices.get(r.nextInt(indices.size())));
+        return joinTokens(pieces);
+    }
+
+    // swaps two random non-whitespace tokens, keeping whitespace runs in place
+    public static String swapRandomTokens(Random r, String input) {
+        List<String> pieces = splitTokens(input);
+        List<Integer> indices = nonWhitespaceIndices(pieces);
+        if (indices.size() < 2) return input;
+
+        int a = indices.get(r.nextInt(indices.size()));
+        int b = indices.get(r.nextInt(indices.size()));
+        while (b == a) {
+            b = indices.get(r.nextInt(indices.size()));
+        }
+
+        String tmp = pieces.get(a);
+        pieces.set(a, pieces.get(b));
+        pieces.set(b, tmp);
+        return joinTokens(pieces);
+    }
+
+    /* word-level mutations, simpler and lossy with respect to original whitespace */
+
+    // deletes one random whitespace-delimited word
+    public static String deleteRandomWord(Random r, String input) {
+        List<String> words = new ArrayList<>(Arrays.asList(input.trim().split("\\s+")));
+        if (words.isEmpty() || words.get(0).isEmpty()) return input;
+
+        words.remove(r.nextInt(words.size()));
+        return String.join(" ", words);
+    }
+
+    // swaps two random whitespace-delimited words
+    public static String swapRandomWords(Random r, String input) {
+        String[] words = input.trim().split("\\s+");
+        if (words.length < 2) return input;
+
+        int a = r.nextInt(words.length);
+        int b = r.nextInt(words.length);
+        while (b == a) {
+            b = r.nextInt(words.length);
+        }
+
+        String tmp = words[a];
+        words[a] = words[b];
+        words[b] = tmp;
+        return String.join(" ", words);
     }
 }

--- a/core/java/src/test/java/org/phylospec/lexer/LexerTest.java
+++ b/core/java/src/test/java/org/phylospec/lexer/LexerTest.java
@@ -187,26 +187,17 @@ public class LexerTest {
 
         // 6th line: 10.5  // this is some comment
         assertEquals(new Token(TokenType.FLOAT, "10.5", 10.5, 6, 0, 4), tokens.get(20));
-        assertEquals(
-                new Token(
-                        TokenType.COMMENT,
-                        "// this is some comment",
-                        " this is some comment",
-                        6,
-                        6,
-                        29),
-                tokens.get(21));
-        assertEquals(new Token(TokenType.EOL, "\n", null, 6, 29, 30), tokens.get(22));
+        assertEquals(new Token(TokenType.EOL, "\n", null, 6, 29, 30), tokens.get(21));
 
         // 7th line: someFun()
-        assertEquals(new Token(TokenType.IDENTIFIER, "someFun", null, 7, 0, 7), tokens.get(23));
-        assertEquals(new Token(TokenType.LEFT_PAREN, "(", null, 7, 7, 8), tokens.get(24));
-        assertEquals(new Token(TokenType.RIGHT_PAREN, ")", null, 7, 8, 9), tokens.get(25));
+        assertEquals(new Token(TokenType.IDENTIFIER, "someFun", null, 7, 0, 7), tokens.get(22));
+        assertEquals(new Token(TokenType.LEFT_PAREN, "(", null, 7, 7, 8), tokens.get(23));
+        assertEquals(new Token(TokenType.RIGHT_PAREN, ")", null, 7, 8, 9), tokens.get(24));
 
         // EOF
-        assertEquals(new Token(TokenType.EOF, "", null, 7, 9, 9), tokens.get(26));
+        assertEquals(new Token(TokenType.EOF, "", null, 7, 9, 9), tokens.get(25));
 
-        assertEquals(tokens.size(), 27);
+        assertEquals(tokens.size(), 26);
     }
 
     @Test

--- a/core/java/src/test/java/org/phylospec/parser/FuzzyParserTest.java
+++ b/core/java/src/test/java/org/phylospec/parser/FuzzyParserTest.java
@@ -1,0 +1,189 @@
+package org.phylospec.parser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+import org.phylospec.FuzzingUtils;
+import org.phylospec.ast.Stmt;
+import org.phylospec.lexer.Lexer;
+import org.phylospec.lexer.Token;
+
+public class FuzzyParserTest {
+
+    @Test
+    public void testFuzz() {
+        Random random = new Random(0);
+
+        for (int i = 0; i < 10000; i++) {
+            String input = generateFuzzInput(random, i);
+            List<Stmt> statements;
+
+            try {
+                List<Token> tokens = new Lexer(input).scanTokens();
+                statements = new Parser(tokens).parse();
+            } catch (Exception e) {
+                fail(
+                        "Parser threw an exception on iteration "
+                                + i
+                                + " (input="
+                                + repr(input)
+                                + "): "
+                                + e);
+                return;
+            }
+
+            // invariant: result and every element are non-null
+            assertNotNull(statements, "statements must not be null (iter=" + i + ")");
+            for (Stmt stmt : statements) {
+                assertNotNull(stmt, "statement must not be null (iter=" + i + ")");
+            }
+        }
+    }
+
+    // generates one fuzz input chosen from several strategies
+    private String generateFuzzInput(Random r, int iteration) {
+        // first few iterations cover deterministic edge cases
+        switch (iteration) {
+            case 0:
+                return "";
+            case 1:
+                return "\n";
+            case 2:
+                return "// comment only";
+            case 3:
+                return "@";
+            case 4:
+                return "=";
+            case 5:
+                return "Real x =";
+            case 6:
+                return "Real x = (";
+            case 7:
+                return "Real x = [";
+            case 8:
+                return "Real<> x = 1";
+            case 9:
+                return "import";
+        }
+
+        int strategy = r.nextInt(5);
+        switch (strategy) {
+            case 0:
+                // random printable ASCII — stresses error recovery
+                return FuzzingUtils.randomString(r, r.nextInt(80) + 1, 32, 126);
+            case 1:
+                // digit-heavy — stresses number parsing interactions with the parser
+                return FuzzingUtils.randomDigitHeavyString(r, r.nextInt(60) + 1);
+            case 2:
+                // mutated valid PhyloSpec snippets — stresses near-valid paths
+                return FuzzingUtils.mutate(r, pickValidStatement(r), r.nextInt(5) + 1);
+            case 3:
+                // multiple lines of mutated statements — stresses error recovery across lines
+                return FuzzingUtils.mutate(r, pickValidStatement(r), r.nextInt(3))
+                        + "\n"
+                        + FuzzingUtils.mutate(r, pickValidStatement(r), r.nextInt(3));
+            default:
+                // full byte range — stresses the lexer+parser pipeline together
+                return FuzzingUtils.randomString(r, r.nextInt(50) + 1, 0, 127);
+        }
+    }
+
+    // fuzzes real, structurally rich models by repeatedly deleting/swapping their
+    // tokens and words, on top of the occasional character-level mutation
+    @Test
+    public void testFuzzComplicatedModels() throws IOException {
+        Random random = new Random(0);
+
+        String[] models = {
+            readFile("src/test/java/org/phylospec/parser/complicated/model1.phylospec"),
+            readFile("src/test/java/org/phylospec/parser/complicated/model2.phylospec"),
+        };
+
+        for (int i = 0; i < 10000; i++) {
+            String input = mutateComplicatedModel(random, models[i % models.length]);
+            List<Stmt> statements;
+
+            try {
+                List<Token> tokens = new Lexer(input).scanTokens();
+                statements = new Parser(tokens).parse();
+            } catch (Exception e) {
+                fail(
+                        "Parser threw an exception on iteration "
+                                + i
+                                + " (input="
+                                + repr(input)
+                                + "): "
+                                + e);
+                return;
+            }
+
+            // invariant: result and every element are non-null
+            assertNotNull(statements, "statements must not be null (iter=" + i + ")");
+            for (Stmt stmt : statements) {
+                assertNotNull(stmt, "statement must not be null (iter=" + i + ")");
+            }
+        }
+    }
+
+    // applies a random number of token-, word-, and character-level mutations in sequence,
+    // so later rounds mutate the already-mutated output of earlier ones
+    private String mutateComplicatedModel(Random r, String source) {
+        String result = source;
+        int rounds = r.nextInt(4) + 1;
+        for (int i = 0; i < rounds; i++) {
+            switch (r.nextInt(5)) {
+                case 0:
+                    result = FuzzingUtils.deleteRandomToken(r, result);
+                    break;
+                case 1:
+                    result = FuzzingUtils.swapRandomTokens(r, result);
+                    break;
+                case 2:
+                    result = FuzzingUtils.deleteRandomWord(r, result);
+                    break;
+                case 3:
+                    result = FuzzingUtils.swapRandomWords(r, result);
+                    break;
+                default:
+                    result = FuzzingUtils.mutate(r, result, 1);
+            }
+        }
+        return result;
+    }
+
+    // reads a source file relative to the module directory
+    private String readFile(String path) throws IOException {
+        return Files.readString(Paths.get(path), StandardCharsets.UTF_8);
+    }
+
+    // valid PhyloSpec statements that cover the main grammar rules
+    private String pickValidStatement(Random r) {
+        String[] snippets = {
+            "Real x = 1.0",
+            "Real x ~ LogNormal(meanLog = 0.0, sdLog = 1.0)",
+            "Real x = a + b * c",
+            "Real x = [1, 2, 3]",
+            "Real x = [v for v in values]",
+            "import phylospec.distributions",
+            "@Observed() Real x ~ Normal(mu = 0.0, sigma = 1.0)",
+            "Real<T> x = func(a = 1, b = 2)",
+            "Real x = (a + b) * (c - d)",
+            "Real x = obj.field",
+            "Real x = f(a = 1,)",
+            "Real x = [1, 2,]",
+        };
+        return snippets[r.nextInt(snippets.length)];
+    }
+
+    // returns a compact representation of a string for failure messages
+    private String repr(String s) {
+        if (s.length() > 60) return "\"" + s.substring(0, 60).replace("\n", "\\n") + "...\"";
+        return "\"" + s.replace("\n", "\\n").replace("\r", "\\r") + "\"";
+    }
+}

--- a/core/java/src/test/java/org/phylospec/parser/ParserTest.java
+++ b/core/java/src/test/java/org/phylospec/parser/ParserTest.java
@@ -1,13 +1,9 @@
 package org.phylospec.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
-import java.util.Random;
 import org.junit.jupiter.api.Test;
-import org.phylospec.FuzzingUtils;
 import org.phylospec.ast.AstType;
 import org.phylospec.ast.Expr;
 import org.phylospec.ast.Stmt;
@@ -269,109 +265,6 @@ public class ParserTest {
                                         new AstType.Atomic("PositiveReal"),
                                         "value",
                                         new Expr.Literal(10)))));
-    }
-
-    @Test
-    public void testFuzz() {
-        Random random = new Random(0);
-
-        for (int i = 0; i < 10000; i++) {
-            String input = generateFuzzInput(random, i);
-            List<Stmt> statements;
-
-            try {
-                List<Token> tokens = new Lexer(input).scanTokens();
-                statements = new Parser(tokens).parse();
-            } catch (Exception e) {
-                fail(
-                        "Parser threw an exception on iteration "
-                                + i
-                                + " (input="
-                                + repr(input)
-                                + "): "
-                                + e);
-                return;
-            }
-
-            // invariant: result and every element are non-null
-            assertNotNull(statements, "statements must not be null (iter=" + i + ")");
-            for (Stmt stmt : statements) {
-                assertNotNull(stmt, "statement must not be null (iter=" + i + ")");
-            }
-        }
-    }
-
-    // generates one fuzz input chosen from several strategies
-    private String generateFuzzInput(Random r, int iteration) {
-        // first few iterations cover deterministic edge cases
-        switch (iteration) {
-            case 0:
-                return "";
-            case 1:
-                return "\n";
-            case 2:
-                return "// comment only";
-            case 3:
-                return "@";
-            case 4:
-                return "=";
-            case 5:
-                return "Real x =";
-            case 6:
-                return "Real x = (";
-            case 7:
-                return "Real x = [";
-            case 8:
-                return "Real<> x = 1";
-            case 9:
-                return "import";
-        }
-
-        int strategy = r.nextInt(5);
-        switch (strategy) {
-            case 0:
-                // random printable ASCII — stresses error recovery
-                return FuzzingUtils.randomString(r, r.nextInt(80) + 1, 32, 126);
-            case 1:
-                // digit-heavy — stresses number parsing interactions with the parser
-                return FuzzingUtils.randomDigitHeavyString(r, r.nextInt(60) + 1);
-            case 2:
-                // mutated valid PhyloSpec snippets — stresses near-valid paths
-                return FuzzingUtils.mutate(r, pickValidStatement(r), r.nextInt(5) + 1);
-            case 3:
-                // multiple lines of mutated statements — stresses error recovery across lines
-                return FuzzingUtils.mutate(r, pickValidStatement(r), r.nextInt(3))
-                        + "\n"
-                        + FuzzingUtils.mutate(r, pickValidStatement(r), r.nextInt(3));
-            default:
-                // full byte range — stresses the lexer+parser pipeline together
-                return FuzzingUtils.randomString(r, r.nextInt(50) + 1, 0, 127);
-        }
-    }
-
-    // valid PhyloSpec statements that cover the main grammar rules
-    private String pickValidStatement(Random r) {
-        String[] snippets = {
-            "Real x = 1.0",
-            "Real x ~ LogNormal(meanLog = 0.0, sdLog = 1.0)",
-            "Real x = a + b * c",
-            "Real x = [1, 2, 3]",
-            "Real x = [v for v in values]",
-            "import phylospec.distributions",
-            "@Observed() Real x ~ Normal(mu = 0.0, sigma = 1.0)",
-            "Real<T> x = func(a = 1, b = 2)",
-            "Real x = (a + b) * (c - d)",
-            "Real x = obj.field",
-            "Real x = f(a = 1,)",
-            "Real x = [1, 2,]",
-        };
-        return snippets[r.nextInt(snippets.length)];
-    }
-
-    // returns a compact representation of a string for failure messages
-    private String repr(String s) {
-        if (s.length() > 60) return "\"" + s.substring(0, 60).replace("\n", "\\n") + "...\"";
-        return "\"" + s.replace("\n", "\\n").replace("\r", "\\r") + "\"";
     }
 
     @Test

--- a/core/java/src/test/java/org/phylospec/parser/arrays/arrays.phylospec
+++ b/core/java/src/test/java/org/phylospec/parser/arrays/arrays.phylospec
@@ -1,16 +1,16 @@
-Vector<Real> vector = [
+Vector<Real> vector1 = [
     10.0,
     2.0,
     -5.0
 ]
 
-Vector<Real> vector = [10.0,]
+Vector<Real> vector2 = [10.0,]
 
-Vector<PositiveReal> vector = [
+Vector<PositiveReal> vector3 = [
     10.0,
 ]
 
-Vector<String> vector = [
+Vector<String> vector4 = [
 
     "10"
 
@@ -23,10 +23,10 @@ Vector<Distribution<Real>> components = [
 ];
 
 // EXPECT AST
-// (AS Vector<Real> vector (AR 10.0 2.0 (- 5.0)))
-// (AS Vector<Real> vector (AR 10.0))
-// (AS Vector<PositiveReal> vector (AR 10.0))
-// (AS Vector<String> vector (AR "10"))
+// (AS Vector<Real> vector1 (AR 10.0 2.0 (- 5.0)))
+// (AS Vector<Real> vector2 (AR 10.0))
+// (AS Vector<PositiveReal> vector3 (AR 10.0))
+// (AS Vector<String> vector4 (AR "10"))
 // (AS Vector<Distribution<Real>> components (AR (CA Normal (AA mean 0.0) (AA sd 1.0)) (CA Normal (AA mean 5.0) (AA sd 2.0)) (CA Normal (AA mean 10.0) (AA sd 1.5))))
 // EXPECT AST
 

--- a/core/java/src/test/java/org/phylospec/parser/arrays/newlines.phylospec
+++ b/core/java/src/test/java/org/phylospec/parser/arrays/newlines.phylospec
@@ -1,4 +1,4 @@
-Vector<Real> vector = [
+Vector<Real> vector1 = [
     log
     (
         x = exp(
@@ -10,12 +10,12 @@ Vector<Real> vector = [
 
     )
 ]
-Vector<Real> vector = [          10           ]
+Vector<Real> vector2 = [          10           ]
 
 
 // EXPECT AST
-// (AS Vector<Real> vector (AR (CA log (AA x (CA exp (AA null 5.0))) (AA base 10))))
-// (AS Vector<Real> vector (AR 10))
+// (AS Vector<Real> vector1 (AR (CA log (AA x (CA exp (AA null 5.0))) (AA base 10))))
+// (AS Vector<Real> vector2 (AR 10))
 // EXPECT AST
 
 // EXPECT TYPE_ERRORS

--- a/core/java/src/test/java/org/phylospec/parser/blocks/blocks.phylospec
+++ b/core/java/src/test/java/org/phylospec/parser/blocks/blocks.phylospec
@@ -34,5 +34,5 @@ revbayes {
 // EXPECT AST
 
 // EXPECT TYPE_ERRORS
-// Wrong argument type for function `Normal` and argument `sd`.
+// Wrong argument type for function `Normal` and argument `sd`. You need to use a value of type 'phylospec.types.PositiveReal'.
 // EXPECT TYPE_ERRORS

--- a/core/java/src/test/java/org/phylospec/parser/comments/modelComments.phylospec
+++ b/core/java/src/test/java/org/phylospec/parser/comments/modelComments.phylospec
@@ -1,0 +1,22 @@
+// this is a line comment
+
+
+Real x = 10 // this is an end-of-line comment
+
+// this is another line comment
+Real y = 10
+
+Real z = log( // something
+    // something else
+    x=10 // something blue
+    // something cool
+) // something new
+
+// something new
+
+
+// EXPECT AST
+// (AS Real x 10)
+// (AS Real y 10)
+// (AS Real z (CA log (AA x 10)))
+// EXPECT AST

--- a/core/java/src/test/java/org/phylospec/parser/decorators/decorators.phylospec
+++ b/core/java/src/test/java/org/phylospec/parser/decorators/decorators.phylospec
@@ -3,11 +3,11 @@ Real x = 100.0;
 
 @observed(50, test=true)
 @beast2(verbosity = "debug")
-Real x = 100.0;
+Real y = 100.0;
 
 // EXPECT AST
 // (@ (CA observed (AA null 50)) (AS Real x 100.0))
-// (@ (CA observed (AA null 50) (AA test true)) (@ (CA beast2 (AA verbosity "debug")) (AS Real x 100.0)))
+// (@ (CA observed (AA null 50) (AA test true)) (@ (CA beast2 (AA verbosity "debug")) (AS Real y 100.0)))
 // EXPECT AST
 
 // EXPECT TYPE_ERRORS

--- a/core/java/src/test/java/org/phylospec/parser/expressions/positiveReal.phylospec
+++ b/core/java/src/test/java/org/phylospec/parser/expressions/positiveReal.phylospec
@@ -1,13 +1,13 @@
 PositiveReal a = 100 * 50 / 2 + 10.0 + (20.0 + 2) / 3
-NonNegativeReal a = 100 * 50 / 2 + 10.0 + (20.0 + 2) / 3
-PositiveReal a = 0 * 50 / 2 + 10.0 + (20.0 + 2) / 3
+NonNegativeReal b = 100 * 50 / 2 + 10.0 + (20.0 + 2) / 3
+PositiveReal c = 0 * 50 / 2 + 10.0 + (20.0 + 2) / 3
 
 // EXPECT AST
 // (AS PositiveReal a (+ (+ (/ (* 100 50) 2) 10.0) (/ (GR (+ 20.0 2)) 3)))
-// (AS NonNegativeReal a (+ (+ (/ (* 100 50) 2) 10.0) (/ (GR (+ 20.0 2)) 3)))
-// (AS PositiveReal a (+ (+ (/ (* 0 50) 2) 10.0) (/ (GR (+ 20.0 2)) 3)))
+// (AS NonNegativeReal b (+ (+ (/ (* 100 50) 2) 10.0) (/ (GR (+ 20.0 2)) 3)))
+// (AS PositiveReal c (+ (+ (/ (* 0 50) 2) 10.0) (/ (GR (+ 20.0 2)) 3)))
 // EXPECT AST
 
 // EXPECT TYPE_ERRORS
-// Expression of type `NonNegativeReal | Real` cannot be assigned to variable `a` of type `PositiveReal`. Change the type of the variable to `NonNegativeReal | Real`, or change what you assign to it.
+// Expression of type `NonNegativeReal | Real` cannot be assigned to variable `c` of type `PositiveReal`. Change the type of the variable to `NonNegativeReal | Real`, or change what you assign to it.
 // EXPECT TYPE_ERRORS

--- a/core/java/src/test/java/org/phylospec/parser/uniquenames/nonUniqueNames.phylospec
+++ b/core/java/src/test/java/org/phylospec/parser/uniquenames/nonUniqueNames.phylospec
@@ -1,0 +1,8 @@
+Real x = 10
+String x = "10"
+Real matrix[i, i] = 1.0 for i in 1:5 for i in 1:5
+
+// EXPECT TYPE_ERRORS
+// Duplicate variable name. You have already used the variable name 'x' before. Use another name instead.
+// Duplicate indices. You use the same index name multiple times. Use a distinct name for each index.
+// EXPECT TYPE_ERRORS

--- a/core/java/src/test/java/org/phylospec/parser/uniquenames/nonUniqueNames.phylospec
+++ b/core/java/src/test/java/org/phylospec/parser/uniquenames/nonUniqueNames.phylospec
@@ -1,8 +1,12 @@
 Real x = 10
 String x = "10"
-Real matrix[i, i] = 1.0 for i in 1:5 for i in 1:5
+
+// EXPECT AST
+// (AS Real x 10)
+// (AS String x "10")
+// EXPECT AST
+
 
 // EXPECT TYPE_ERRORS
 // Duplicate variable name. You have already used the variable name 'x' before. Use another name instead.
-// Duplicate indices. You use the same index name multiple times. Use a distinct name for each index.
 // EXPECT TYPE_ERRORS

--- a/core/java/src/test/java/org/phylospec/typeresolver/FuzzyTest.java
+++ b/core/java/src/test/java/org/phylospec/typeresolver/FuzzyTest.java
@@ -1,4 +1,4 @@
-package org.phylospec.parser;
+package org.phylospec.typeresolver;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -11,14 +11,21 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 import org.phylospec.FuzzingUtils;
 import org.phylospec.ast.Stmt;
+import org.phylospec.components.ComponentLibrary;
+import org.phylospec.components.ComponentResolver;
 import org.phylospec.lexer.Lexer;
 import org.phylospec.lexer.Token;
+import org.phylospec.parser.Parser;
 
-public class FuzzyParserTest {
+public class FuzzyTest {
 
     @Test
-    public void testFuzz() {
+    public void testFuzz() throws IOException {
         Random random = new Random(0);
+
+        List<ComponentLibrary> componentLibraries = ComponentResolver.loadCoreComponentLibraries();
+        ComponentResolver componentResolver = new ComponentResolver(componentLibraries);
+        TypeResolver typeResolver = new TypeResolver(componentResolver);
 
         for (int i = 0; i < 10000; i++) {
             String input = generateFuzzInput(random, i);
@@ -27,6 +34,21 @@ public class FuzzyParserTest {
             try {
                 List<Token> tokens = new Lexer(input).scanTokens();
                 statements = new Parser(tokens).parse();
+            } catch (Exception e) {
+                fail(
+                        "Parser threw an exception on iteration "
+                                + i
+                                + " (input="
+                                + repr(input)
+                                + "): "
+                                + e);
+                return;
+            }
+
+            try {
+                typeResolver.visitStatements(statements);
+            } catch (TypeError e) {
+                // this is fine
             } catch (Exception e) {
                 fail(
                         "Parser threw an exception on iteration "
@@ -105,6 +127,10 @@ public class FuzzyParserTest {
             readFile("src/test/java/org/phylospec/parser/complicated/model2.phylospec"),
         };
 
+        List<ComponentLibrary> componentLibraries = ComponentResolver.loadCoreComponentLibraries();
+        ComponentResolver componentResolver = new ComponentResolver(componentLibraries);
+        TypeResolver typeResolver = new TypeResolver(componentResolver);
+
         for (int i = 0; i < 10000; i++) {
             String input = mutateComplicatedModel(random, models[i % models.length]);
             List<Stmt> statements;
@@ -112,6 +138,21 @@ public class FuzzyParserTest {
             try {
                 List<Token> tokens = new Lexer(input).scanTokens();
                 statements = new Parser(tokens).parse();
+            } catch (Exception e) {
+                fail(
+                        "Parser threw an exception on iteration "
+                                + i
+                                + " (input="
+                                + repr(input)
+                                + "): "
+                                + e);
+                return;
+            }
+
+            try {
+                typeResolver.visitStatements(statements);
+            } catch (TypeError e) {
+                // this is fine
             } catch (Exception e) {
                 fail(
                         "Parser threw an exception on iteration "


### PR DESCRIPTION
These commits add some minor improvements and fixes to the PhyloSpec core:

- A bug wrt. parsing of comments in multiline statements has been fixed.
- A bug was fixed where the wrong tokens were highlighted by the LSP when an affected variable was used multiple times.
- Uniqueness of variable names is now actually enforced by the type resolver.
- Empty generics are valid now (i.e. `Real<>` is equal to `Real`).
- More useful error messages have been added for some edge cases.
- Some more fuzzing tests have been added to the parser, lexer and type resolver.