### PR TITLE
Fix BEAST X relaxed-clock category operators

### DIFF
--- a/integrations/beastx/java/src/main/java/tiling/operators/OperatorBuilder.java
+++ b/integrations/beastx/java/src/main/java/tiling/operators/OperatorBuilder.java
@@ -8,13 +8,17 @@ import dr.evomodel.operators.UniformNodeHeightOperator;
 import dr.evomodel.operators.WilsonBalding;
 import dr.evomodel.tree.DefaultTreeModel;
 import dr.evomodel.tree.TreeModel;
+import dr.inference.model.Bounds;
 import dr.inference.model.Parameter;
 import dr.inference.operators.AdaptationMode;
 import dr.inference.operators.DeltaExchangeOperator;
 import dr.inference.operators.MCMCOperator;
+import dr.inference.operators.RandomWalkIntegerOperator;
 import dr.inference.operators.RandomWalkOperator;
 import dr.inference.operators.Scalable;
 import dr.inference.operators.ScaleOperator;
+import dr.inference.operators.SwapOperator;
+import dr.inference.operators.UniformIntegerOperator;
 import dr.inference.operators.UpDownOperator;
 import org.phylospec.domain.NonNegativeReal;
 import org.phylospec.domain.PositiveReal;
@@ -75,11 +79,18 @@ public class OperatorBuilder {
         entries.sort(Comparator.comparing(entry -> parameterId(entry.getKey())));
 
         for (Map.Entry<Parameter, TypeToken<?>> entry : entries) {
-            operators.add(buildParameterOperator(
-                    entry.getKey(),
-                    entry.getValue(),
-                    beastState.operatorConfig
-            ));
+            Parameter parameter =
+                    entry.getKey();
+
+            if (isRelaxedClockRateCategoriesParameter(beastState, parameter)) {
+                operators.addAll(buildRelaxedClockCategoryOperators(parameter));
+            } else {
+                operators.add(buildParameterOperator(
+                        parameter,
+                        entry.getValue(),
+                        beastState.operatorConfig
+                ));
+            }
         }
 
         return operators;
@@ -95,11 +106,18 @@ public class OperatorBuilder {
         entries.sort(Comparator.comparing(entry -> parameterId(entry.getKey())));
 
         for (Map.Entry<Parameter, TypeToken<?>> entry : entries) {
-            summaries.add(summarizeParameterOperator(
-                    entry.getKey(),
-                    entry.getValue(),
-                    beastState.operatorConfig
-            ));
+            Parameter parameter =
+                    entry.getKey();
+
+            if (isRelaxedClockRateCategoriesParameter(beastState, parameter)) {
+                summaries.addAll(summarizeRelaxedClockCategoryOperators(parameter));
+            } else {
+                summaries.add(summarizeParameterOperator(
+                        parameter,
+                        entry.getValue(),
+                        beastState.operatorConfig
+                ));
+            }
         }
 
         return summaries;
@@ -258,6 +276,81 @@ public class OperatorBuilder {
                 config.parameterOperatorWeight,
                 AdaptationMode.DEFAULT
         );
+    }
+
+    private List<MCMCOperator> buildRelaxedClockCategoryOperators(
+            Parameter parameter
+    ) {
+        List<MCMCOperator> operators =
+                new ArrayList<>();
+
+        operators.add(new RandomWalkIntegerOperator(
+                parameter,
+                1,
+                10.0
+        ));
+
+        SwapOperator swapOperator =
+                new SwapOperator(parameter, 1);
+
+        swapOperator.setWeight(10.0);
+        operators.add(swapOperator);
+
+        Bounds<Double> bounds =
+                parameter.getBounds();
+
+        int lower =
+                (int) Math.ceil(bounds.getLowerLimit(0));
+
+        int upper =
+                (int) Math.floor(bounds.getUpperLimit(0));
+
+        operators.add(new UniformIntegerOperator(
+                parameter,
+                lower,
+                upper,
+                10.0,
+                1
+        ));
+
+        return operators;
+    }
+
+    private List<String> summarizeRelaxedClockCategoryOperators(
+            Parameter parameter
+    ) {
+        Bounds<Double> bounds =
+                parameter.getBounds();
+
+        int lower =
+                (int) Math.ceil(bounds.getLowerLimit(0));
+
+        int upper =
+                (int) Math.floor(bounds.getUpperLimit(0));
+
+        String id =
+                parameterId(parameter);
+
+        return List.of(
+                "RandomWalkIntegerOperator(parameter=%s, weight=10.0, windowSize=1)".formatted(id),
+                "SwapOperator(parameter=%s, weight=10.0, size=1)".formatted(id),
+                "UniformIntegerOperator(parameter=%s, weight=10.0, count=1, lower=%d, upper=%d)"
+                        .formatted(id, lower, upper)
+        );
+    }
+
+    private boolean isRelaxedClockRateCategoriesParameter(
+            BeastXState state,
+            Parameter parameter
+    ) {
+        return state.treeRelaxedClockModels
+                .values()
+                .stream()
+                .map(BeastXState.RelaxedClockSpec::rateCategoriesParameter)
+                .anyMatch(rateCategories ->
+                        rateCategories == parameter
+                                || parameterId(rateCategories).equals(parameterId(parameter))
+                );
     }
 
     private String summarizeParameterOperator(

--- a/integrations/beastx/java/src/test/java/BeastXRelaxedClockCategoryOperatorTest.java
+++ b/integrations/beastx/java/src/test/java/BeastXRelaxedClockCategoryOperatorTest.java
@@ -1,0 +1,130 @@
+import dr.inference.model.Bounds;
+import dr.inference.model.Parameter;
+import dr.inference.operators.MCMCOperator;
+import dr.inference.operators.RandomWalkIntegerOperator;
+import dr.inference.operators.SwapOperator;
+import dr.inference.operators.UniformIntegerOperator;
+import dr.math.MathUtils;
+import org.junit.jupiter.api.Test;
+import tiling.BeastXState;
+import tiling.operators.OperatorBuilder;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class BeastXRelaxedClockCategoryOperatorTest {
+
+    private static final Path RELAXED_CLOCK_MODEL =
+            Path.of(
+                    "src",
+                    "test",
+                    "java",
+                    "tiling",
+                    "branchmodels",
+                    "relaxedClock.phylospec"
+            );
+
+    @Test
+    public void categoryOperatorsUseIntegerMovesAndParameterBounds() throws Exception {
+        BeastXState state =
+                PhyloSpecRunner
+                        .fromFile(RELAXED_CLOCK_MODEL)
+                        .buildState("relaxedClockCategoryOperators");
+
+        Parameter categories =
+                state.treeRelaxedClockModels
+                        .values()
+                        .stream()
+                        .findFirst()
+                        .orElseThrow()
+                        .rateCategoriesParameter();
+
+        List<MCMCOperator> categoryOperators =
+                new OperatorBuilder()
+                        .build(state)
+                        .stream()
+                        .filter(operator -> operator.getOperatorName().contains(categories.getId()))
+                        .toList();
+
+        assertEquals(3, categoryOperators.size());
+        assertInstanceOf(RandomWalkIntegerOperator.class, categoryOperators.get(0));
+        assertInstanceOf(SwapOperator.class, categoryOperators.get(1));
+
+        UniformIntegerOperator actualOperator =
+                assertInstanceOf(
+                        UniformIntegerOperator.class,
+                        categoryOperators.get(2)
+                );
+
+        Bounds<Double> bounds =
+                categories.getBounds();
+
+        int lower =
+                (int) Math.ceil(bounds.getLowerLimit(0));
+
+        int upper =
+                (int) Math.floor(bounds.getUpperLimit(0));
+
+        Parameter referenceCategories =
+                new Parameter.Default(categories.getParameterValues());
+
+        referenceCategories.addBounds(
+                new Parameter.DefaultBounds(
+                        upper,
+                        lower,
+                        referenceCategories.getDimension()
+                )
+        );
+
+        UniformIntegerOperator referenceOperator =
+                new UniformIntegerOperator(
+                        referenceCategories,
+                        lower,
+                        upper,
+                        10.0,
+                        1
+                );
+
+        for (long seed = 1; seed <= 20; seed++) {
+            resetCategories(categories, lower, upper);
+            resetCategories(referenceCategories, lower, upper);
+
+            MathUtils.setSeed(seed);
+            actualOperator.operate();
+            actualOperator.accept(0.0);
+
+            MathUtils.setSeed(seed);
+            referenceOperator.operate();
+            referenceOperator.accept(0.0);
+
+            assertArrayEquals(
+                    referenceCategories.getParameterValues(),
+                    categories.getParameterValues(),
+                    0.0,
+                    "Uniform category proposal differs for seed " + seed
+            );
+        }
+    }
+
+    private void resetCategories(
+            Parameter parameter,
+            int lower,
+            int upper
+    ) {
+        int numberOfValues =
+                upper - lower + 1;
+
+        for (int index = 0; index < parameter.getDimension(); index++) {
+            parameter.setParameterValueQuietly(
+                    index,
+                    lower + index % numberOfValues
+            );
+        }
+
+        parameter.fireParameterChangedEvent();
+    }
+}

--- a/integrations/beastx/java/src/test/java/BeastXRepresentativeModelsTest.java
+++ b/integrations/beastx/java/src/test/java/BeastXRepresentativeModelsTest.java
@@ -240,14 +240,18 @@ public class BeastXRepresentativeModelsTest {
                 "DeltaExchangeOperator",
                 "ExchangeOperator",
                 "NodeHeightScaleOperator",
-                "RandomWalkOperator",
+                "RandomWalkIntegerOperator",
                 "ScaleOperator",
                 "SubtreeSlideOperator",
+                "SwapOperator",
+                "UniformIntegerOperator",
                 "WilsonBalding"
         );
 
         assertAnyContains(summary.operatorDetails, "DeltaExchangeOperator(parameter=baseFrequencies");
-        assertAnyContains(summary.operatorDetails, "RandomWalkOperator(parameter=branchRateCategories");
+        assertAnyContains(summary.operatorDetails, "RandomWalkIntegerOperator(parameter=branchRateCategories");
+        assertAnyContains(summary.operatorDetails, "SwapOperator(parameter=branchRateCategories");
+        assertAnyContains(summary.operatorDetails, "UniformIntegerOperator(parameter=branchRateCategories");
         assertAnyContains(summary.operatorDetails, "ScaleOperator(parameter=clockRate");
         assertAnyContains(summary.operatorDetails, "ScaleOperator(parameter=diversificationRate");
         assertAnyContains(summary.operatorDetails, "ScaleOperator(parameter=serialSamplingRate");


### PR DESCRIPTION
## Summary

This PR fixes the default operator selection for BEAST X relaxed-clock rate-category parameters.

The relaxed-clock category parameter is integer-valued, so it should be updated using integer-specific proposals rather than the generic operators used for continuous parameters.

The updated operator schedule includes:

- `RandomWalkIntegerOperator`
- `SwapOperator`
- `UniformIntegerOperator`

The bounds of the uniform integer proposal are derived directly from the bounds of the rate-category parameter.

## Root cause

The relaxed-clock rate categories were previously handled by the generic parameter-operator selection logic. This did not provide an appropriate proposal schedule for an integer-valued category parameter and could produce invalid or ineffective proposals during MCMC sampling.

## Changes

- detect relaxed-clock rate-category parameters in `OperatorBuilder`
- construct integer-specific category operators
- use the category parameter bounds for uniform proposals
- add a focused regression test for operator types and proposal bounds
- update the representative relaxed-clock model test

## Validation

The regression test verifies that:

- exactly three category operators are generated
- the operators have the expected integer-specific types
- uniform proposals remain within the category parameter bounds
- the representative relaxed-clock model uses the updated operator schedule

## Scope

This PR intentionally focuses on the BEAST X relaxed-clock category-operator bug. Broader cross-engine validation and benchmark infrastructure remain separate from this fix.