### PR TITLE
Add BEAST X support for observed tree distributions

### DIFF
--- a/integrations/beastx/java/src/main/java/tiles/BeastXCoreTileLibrary.java
+++ b/integrations/beastx/java/src/main/java/tiles/BeastXCoreTileLibrary.java
@@ -83,6 +83,7 @@ import tiles.observations.ObservedAsAlignmentTile;
 import tiles.observations.RootObservedBetweenTile;
 import tiles.observations.MRCAObservedBetweenTile;
 import tiles.observations.ObservedAsTile;
+import tiles.observations.ObservedAsTreeTile;
 import tiles.observations.ObservedAsNonNegativeIntTile;
 import tiles.observations.ObservedAsIntTile;
 
@@ -143,6 +144,7 @@ public class BeastXCoreTileLibrary extends TileLibrary<BeastXState> {
         tiles.add(new DrawTile());
         tiles.add(new TreeDrawTile());
         tiles.add(new ObservedAsAlignmentTile());
+        tiles.add(new ObservedAsTreeTile());
         tiles.add(new ObservedAsTile());
         tiles.add(new ObservedAsNonNegativeIntTile());
         tiles.add(new ObservedAsIntTile());

--- a/integrations/beastx/java/src/main/java/tiles/observations/ObservedAsTreeTile.java
+++ b/integrations/beastx/java/src/main/java/tiles/observations/ObservedAsTreeTile.java
@@ -1,0 +1,66 @@
+package tiles.observations;
+
+import dr.evomodel.tree.TreeModel;
+import dr.inference.model.AbstractModelLikelihood;
+import org.phylospec.ast.Expr;
+import org.phylospec.ast.Stmt;
+import org.phylospec.tiling.TypeToken;
+import org.phylospec.tiling.tiles.TemplateTile;
+import tiling.BeastXState;
+import tiling.model.BoundDistribution;
+
+import java.util.IdentityHashMap;
+
+/**
+ * Evaluates a BEAST X tree distribution on a fixed observed tree.
+ */
+public class ObservedAsTreeTile extends TemplateTile<TreeModel, BeastXState> {
+
+    @Override
+    protected String getPhyloSpecTemplate() {
+        return "Any x ~ $distribution observed as $observation";
+    }
+
+    TemplateTileInput<
+            BoundDistribution<TreeModel, ? extends AbstractModelLikelihood>,
+            BeastXState
+            > distributionInput =
+            new TemplateTileInput<>("$distribution");
+
+    TemplateTileInput<TreeModel, BeastXState> observationInput =
+            new TemplateTileInput<>("$observation");
+
+    @Override
+    public TreeModel applyTile(
+            BeastXState beastState,
+            IdentityHashMap<Expr.Variable, Integer> indexVariables
+    ) {
+        BoundDistribution<TreeModel, ? extends AbstractModelLikelihood> distribution =
+                this.distributionInput.apply(beastState, indexVariables);
+
+        TreeModel observedTree =
+                this.observationInput.apply(beastState, indexVariables);
+
+        String treeId =
+                this.getRootNode() instanceof Stmt stmt
+                        ? this.getId(stmt.getName(), indexVariables, "")
+                        : this.getId("tree", indexVariables, "");
+
+        String likelihoodId =
+                treeId + "_likelihood";
+
+        distribution.bind(observedTree);
+
+        return beastState.addObservedTreeDistribution(
+                observedTree,
+                distribution.distribution,
+                treeId,
+                likelihoodId
+        );
+    }
+
+    @Override
+    public TypeToken<?> getTypeToken() {
+        return this.observationInput.getTypeToken();
+    }
+}

--- a/integrations/beastx/java/src/main/java/tiles/trees/BirthDeathTile.java
+++ b/integrations/beastx/java/src/main/java/tiles/trees/BirthDeathTile.java
@@ -5,6 +5,7 @@ import dr.evolution.util.Units;
 import dr.evomodel.speciation.BirthDeathGernhard08Model;
 import dr.evomodel.speciation.SpeciationLikelihood;
 import dr.evomodel.tree.DefaultTreeModel;
+import dr.evomodel.tree.TreeModel;
 import dr.inference.model.Parameter;
 import org.phylospec.ast.Expr;
 import org.phylospec.domain.NonNegativeReal;
@@ -19,7 +20,7 @@ import tiling.params.BeastXParameters;
 import java.util.IdentityHashMap;
 
 public class BirthDeathTile extends GeneratorTile<
-        BoundDistribution<DefaultTreeModel, SpeciationLikelihood>,
+        BoundDistribution<TreeModel, SpeciationLikelihood>,
         BeastXState
         > {
 
@@ -44,7 +45,7 @@ public class BirthDeathTile extends GeneratorTile<
             new GeneratorTileInput<>("taxa");
 
     @Override
-    public BoundDistribution<DefaultTreeModel, SpeciationLikelihood> applyTile(
+    public BoundDistribution<TreeModel, SpeciationLikelihood> applyTile(
             BeastXState beastState,
             IdentityHashMap<Expr.Variable, Integer> indexVariables
     ) {
@@ -83,18 +84,14 @@ public class BirthDeathTile extends GeneratorTile<
                         Units.Type.YEARS
                 );
 
-        SpeciationLikelihood likelihood =
-                new SpeciationLikelihood(
-                        defaultTreeModel,
-                        birthDeathModel,
-                        "birthDeathPrior"
-                );
-
         return new BoundDistribution<>(
-                likelihood,
                 defaultTreeModel,
                 treeModel -> {
-                    // SpeciationLikelihood receives the tree in its constructor.
+                    return new SpeciationLikelihood(
+                            treeModel,
+                            birthDeathModel,
+                            "birthDeathPrior"
+                    );
                 }
         );
     }

--- a/integrations/beastx/java/src/main/java/tiles/trees/YuleTile.java
+++ b/integrations/beastx/java/src/main/java/tiles/trees/YuleTile.java
@@ -5,6 +5,7 @@ import dr.evolution.util.Units;
 import dr.evomodel.speciation.BirthDeathGernhard08Model;
 import dr.evomodel.speciation.SpeciationLikelihood;
 import dr.evomodel.tree.DefaultTreeModel;
+import dr.evomodel.tree.TreeModel;
 import dr.inference.model.Parameter;
 import org.phylospec.ast.Expr;
 import org.phylospec.domain.NonNegativeReal;
@@ -18,7 +19,7 @@ import tiling.params.BeastXParameters;
 import java.util.IdentityHashMap;
 
 public class YuleTile extends GeneratorTile<
-        BoundDistribution<DefaultTreeModel, SpeciationLikelihood>,
+        BoundDistribution<TreeModel, SpeciationLikelihood>,
         BeastXState
         > {
 
@@ -37,7 +38,7 @@ public class YuleTile extends GeneratorTile<
             new GeneratorTileInput<>("taxa");
 
     @Override
-    public BoundDistribution<DefaultTreeModel, SpeciationLikelihood> applyTile(
+    public BoundDistribution<TreeModel, SpeciationLikelihood> applyTile(
             BeastXState beastState,
             IdentityHashMap<Expr.Variable, Integer> indexVariables
     ) {
@@ -65,18 +66,14 @@ public class YuleTile extends GeneratorTile<
                         Units.Type.YEARS
                 );
 
-        SpeciationLikelihood likelihood =
-                new SpeciationLikelihood(
-                        defaultTreeModel,
-                        yuleModel,
-                        "yulePrior"
-                );
-
         return new BoundDistribution<>(
-                likelihood,
                 defaultTreeModel,
                 treeModel -> {
-                    // SpeciationLikelihood receives the tree in its constructor.
+                    return new SpeciationLikelihood(
+                            treeModel,
+                            yuleModel,
+                            "yulePrior"
+                    );
                 }
         );
     }

--- a/integrations/beastx/java/src/main/java/tiling/BeastXModel.java
+++ b/integrations/beastx/java/src/main/java/tiling/BeastXModel.java
@@ -101,8 +101,13 @@ public class BeastXModel {
     }
 
     private static CompoundLikelihood buildLikelihood(BeastXState beastState) {
+        List<Likelihood> likelihoods =
+                new ArrayList<>(beastState.likelihoodDistributions);
+
+        likelihoods.addAll(beastState.observedTreeDistributions.values());
+
         CompoundLikelihood likelihood =
-                new CompoundLikelihood(new ArrayList<>(beastState.likelihoodDistributions));
+                new CompoundLikelihood(likelihoods);
 
         likelihood.setId(beastState.getAvailableID("likelihood"));
 

--- a/integrations/beastx/java/src/main/java/tiling/BeastXState.java
+++ b/integrations/beastx/java/src/main/java/tiling/BeastXState.java
@@ -47,6 +47,7 @@ public class BeastXState {
     public final Map<String, TreeModel> treeModelsByPhyloSpecName;
     public final Map<Parameter, AbstractDistributionLikelihood> priorDistributions;
     public final Map<TreeModel, AbstractModelLikelihood> treePriorDistributions;
+    public final Map<TreeModel, AbstractModelLikelihood> observedTreeDistributions;
     public final Map<TreeModel, StartingTreeSpec> startingTreeSpecs;
     public final List<AbstractDistributionLikelihood> calibrationPriorDistributions;
     public final List<Likelihood> likelihoodDistributions;
@@ -81,6 +82,7 @@ public class BeastXState {
         this.treeModelsByPhyloSpecName = new HashMap<>();
         this.priorDistributions = new HashMap<>();
         this.treePriorDistributions = new HashMap<>();
+        this.observedTreeDistributions = new HashMap<>();
         this.startingTreeSpecs = new HashMap<>();
         this.calibrationPriorDistributions = new ArrayList<>();
         this.likelihoodDistributions = new ArrayList<>();
@@ -182,6 +184,36 @@ public class BeastXState {
         this.treePriorDistributions.put(treeModel, likelihood);
         this.startingTreeSpecs.put(treeModel, startingTreeSpec);
         this.treeModelsByPhyloSpecName.put(id, treeModel);
+
+        return treeModel;
+    }
+
+    /**
+     * Registers a density evaluated on a fixed observed tree.
+     *
+     * <p>The tree is deliberately kept out of {@link #treePriorDistributions}:
+     * that collection represents sampled trees and drives automatic tree
+     * operator construction. The density still belongs to the model likelihood
+     * and therefore contributes to the posterior.</p>
+     */
+    public TreeModel addObservedTreeDistribution(
+            TreeModel treeModel,
+            AbstractModelLikelihood likelihood,
+            String treeId,
+            String likelihoodId
+    ) {
+        if (this.treeModelsByPhyloSpecName.containsKey(treeId)) {
+            throw new IllegalArgumentException(
+                    "Tree model already registered for PhyloSpec name: " + treeId
+            );
+        }
+
+        treeModel.setId(this.getAvailableID(treeId));
+        likelihood.setId(this.getAvailableID(likelihoodId));
+
+        this.observedTreeDistributions.put(treeModel, likelihood);
+        this.treeModelsByPhyloSpecName.put(treeId, treeModel);
+        this.startingTreeSpecs.put(treeModel, StartingTreeSpec.fixedNewick());
 
         return treeModel;
     }

--- a/integrations/beastx/java/src/main/java/tiling/mcmc/LoggerBuilder.java
+++ b/integrations/beastx/java/src/main/java/tiling/mcmc/LoggerBuilder.java
@@ -315,6 +315,12 @@ public class LoggerBuilder {
             }
         }
 
+        for (Likelihood candidate : beastState.observedTreeDistributions.values()) {
+            if (loggableName.equals(candidate.getId())) {
+                return candidate;
+            }
+        }
+
         for (Likelihood candidate : beastState.calibrationPriorDistributions) {
             if (loggableName.equals(candidate.getId())) {
                 return candidate;

--- a/integrations/beastx/java/src/main/java/tiling/model/BoundDistribution.java
+++ b/integrations/beastx/java/src/main/java/tiling/model/BoundDistribution.java
@@ -1,6 +1,7 @@
 package tiling.model;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Connects a BEAST X likelihood to the PhyloSpec state object it generates or
@@ -13,10 +14,11 @@ import java.util.function.Consumer;
  */
 public class BoundDistribution<T, O> {
 
-    public final O distribution;
+    public O distribution;
     public T stateNode;
     public final StartingTreeSpec startingTreeSpec;
     private final Consumer<T> setStateNodeFunc;
+    private final Function<T, O> distributionFactory;
 
     public BoundDistribution(O distribution, T defaultState, Consumer<T> setStateNodeFunc) {
         this(distribution, defaultState, StartingTreeSpec.fixedNewick(), setStateNodeFunc);
@@ -32,14 +34,46 @@ public class BoundDistribution<T, O> {
         this.stateNode = defaultState;
         this.startingTreeSpec = startingTreeSpec;
         this.setStateNodeFunc = setStateNodeFunc;
+        this.distributionFactory = null;
+    }
+
+    /**
+     * Creates a distribution whose BEAST X likelihood must be constructed only
+     * after its final state object is known. This is required for APIs such as
+     * {@code SpeciationLikelihood}, which receive their tree in the constructor
+     * and cannot be rebound afterwards.
+     */
+    public BoundDistribution(
+            T defaultState,
+            StartingTreeSpec startingTreeSpec,
+            Function<T, O> distributionFactory
+    ) {
+        this.distribution = null;
+        this.stateNode = defaultState;
+        this.startingTreeSpec = startingTreeSpec;
+        this.setStateNodeFunc = null;
+        this.distributionFactory = distributionFactory;
+    }
+
+    public BoundDistribution(
+            T defaultState,
+            Function<T, O> distributionFactory
+    ) {
+        this(defaultState, StartingTreeSpec.fixedNewick(), distributionFactory);
     }
 
     public void bind() {
-        this.setStateNodeFunc.accept(this.stateNode);
+        bind(this.stateNode);
     }
 
     public void bind(T observedStateNode) {
-        this.setStateNodeFunc.accept(observedStateNode);
         this.stateNode = observedStateNode;
+
+        if (this.distributionFactory != null) {
+            this.distribution = this.distributionFactory.apply(observedStateNode);
+            return;
+        }
+
+        this.setStateNodeFunc.accept(observedStateNode);
     }
 }

--- a/integrations/beastx/java/src/main/java/tiling/summary/BeastXModelSummary.java
+++ b/integrations/beastx/java/src/main/java/tiling/summary/BeastXModelSummary.java
@@ -111,6 +111,10 @@ public class BeastXModelSummary {
             treePriors.add(entry.getValue().getId());
         }
 
+        for (Map.Entry<TreeModel, AbstractModelLikelihood> entry : model.beastState.observedTreeDistributions.entrySet()) {
+            treeModels.add(entry.getKey().getId());
+        }
+
         List<String> calibrationPriors = new ArrayList<>();
 
         for (AbstractDistributionLikelihood calibrationPrior : model.beastState.calibrationPriorDistributions) {
@@ -120,6 +124,10 @@ public class BeastXModelSummary {
         List<String> likelihoods = new ArrayList<>();
 
         for (Likelihood likelihood : model.beastState.likelihoodDistributions) {
+            likelihoods.add(likelihood.getId());
+        }
+
+        for (Likelihood likelihood : model.beastState.observedTreeDistributions.values()) {
             likelihoods.add(likelihood.getId());
         }
 

--- a/integrations/beastx/java/src/main/java/tiling/xml/XmlExportValidator.java
+++ b/integrations/beastx/java/src/main/java/tiling/xml/XmlExportValidator.java
@@ -52,6 +52,7 @@ public class XmlExportValidator {
         validateMCMCLoggerRequirement(state);
         validateParameterPriors(state);
         validateTreePriors(state);
+        validateObservedTreeDistributions(state);
     }
 
     private void validateLikelihoodExportBoundary(BeastXState state) {
@@ -72,6 +73,7 @@ public class XmlExportValidator {
         if (
                 state.priorDistributions.isEmpty()
                         && state.treePriorDistributions.isEmpty()
+                        && state.observedTreeDistributions.isEmpty()
                         && state.likelihoodDistributions.isEmpty()
         ) {
             throw unsupported("At least one scalar prior, tree prior, or likelihood is required.");
@@ -147,6 +149,19 @@ public class XmlExportValidator {
             } else {
                 throw unsupported("Only SpeciationLikelihood and CoalescentLikelihood tree priors are supported.");
             }
+        }
+    }
+
+    private void validateObservedTreeDistributions(BeastXState state) {
+        for (AbstractModelLikelihood distribution : state.observedTreeDistributions.values()) {
+            if (distribution instanceof SpeciationLikelihood speciationLikelihood) {
+                validateSpeciationTreePrior(speciationLikelihood);
+                continue;
+            }
+
+            throw unsupported(
+                    "Only observed Yule and BirthDeath tree distributions are supported."
+            );
         }
     }
 

--- a/integrations/beastx/java/src/main/java/tiling/xml/XmlPlanBuilder.java
+++ b/integrations/beastx/java/src/main/java/tiling/xml/XmlPlanBuilder.java
@@ -23,6 +23,7 @@ import tiling.xml.builders.TreePriorXmlBuilder;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -84,6 +85,7 @@ public class XmlPlanBuilder {
 
         addParameterPriors(plan, state);
         addTreePriors(plan, state);
+        addObservedTreeDistributions(plan, state);
         addCalibrationPriors(plan, state);
         addTreeStatistics(plan, state);
         addOperators(plan, state);
@@ -147,9 +149,14 @@ public class XmlPlanBuilder {
         Set<String> emittedTaxonIds =
                 new HashSet<>();
 
+        Set<TreeModel> emittedTreeModels =
+                java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+
         for (Map.Entry<TreeModel, AbstractModelLikelihood> entry : treeEntries) {
             TreeModel treeModel =
                     entry.getKey();
+
+            emittedTreeModels.add(treeModel);
 
             treeModelXmlBuilder.addTreeDefinitions(
                     plan,
@@ -158,6 +165,31 @@ public class XmlPlanBuilder {
                     entry.getValue(),
                     emittedTaxonIds
             );
+
+            plan.add(
+                    XmlPlan.Section.TREE_PRIOR_MODELS,
+                    treePriorModelDefinition(state, entry.getValue())
+            );
+        }
+
+        List<Map.Entry<TreeModel, AbstractModelLikelihood>> observedEntries =
+                new ArrayList<>(state.observedTreeDistributions.entrySet());
+
+        observedEntries.sort(Comparator.comparing(entry -> treeId(entry.getKey())));
+
+        for (Map.Entry<TreeModel, AbstractModelLikelihood> entry : observedEntries) {
+            TreeModel treeModel =
+                    entry.getKey();
+
+            if (emittedTreeModels.add(treeModel)) {
+                treeModelXmlBuilder.addTreeDefinitions(
+                        plan,
+                        state,
+                        treeModel,
+                        entry.getValue(),
+                        emittedTaxonIds
+                );
+            }
 
             plan.add(
                     XmlPlan.Section.TREE_PRIOR_MODELS,
@@ -298,6 +330,23 @@ public class XmlPlanBuilder {
             plan.add(
                     XmlPlan.Section.MCMC_PRIOR,
                     treePrior(entry.getKey(), entry.getValue())
+            );
+        }
+    }
+
+    private void addObservedTreeDistributions(
+            XmlPlan plan,
+            BeastXState state
+    ) {
+        List<Map.Entry<TreeModel, AbstractModelLikelihood>> entries =
+                new ArrayList<>(state.observedTreeDistributions.entrySet());
+
+        entries.sort(Comparator.comparing(entry -> treeId(entry.getKey())));
+
+        for (Map.Entry<TreeModel, AbstractModelLikelihood> entry : entries) {
+            plan.add(
+                    XmlPlan.Section.MCMC_LIKELIHOOD,
+                    treePriorXmlBuilder.buildPrior(entry.getKey(), entry.getValue())
             );
         }
     }

--- a/integrations/beastx/java/src/test/java/BeastXObservedTreeDistributionTest.java
+++ b/integrations/beastx/java/src/test/java/BeastXObservedTreeDistributionTest.java
@@ -1,0 +1,232 @@
+import dr.evomodel.speciation.SpeciationLikelihood;
+import dr.evomodel.tree.TreeModel;
+import dr.inference.mcmc.MCMC;
+import dr.inference.operators.MCMCOperator;
+import org.junit.jupiter.api.Test;
+import tiling.BeastXModel;
+import tiling.mcmc.MCMCBuilder;
+import tiling.operators.OperatorBuilder;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BeastXObservedTreeDistributionTest {
+
+    private static final String OBSERVED_YULE_SOURCE =
+            """
+            Tree treeData = fromNewick(
+                "((A:1.0,B:1.0):1.0,(C:1.0,D:1.0):1.0);"
+            )
+
+            PositiveReal birthRate ~ LogNormal(
+                logMean=0.0,
+                logSd=1.0
+            )
+
+            Tree tree ~ Yule(
+                birthRate=birthRate,
+                taxa=taxa(treeData)
+            ) observed as treeData
+            """;
+
+    private static final String OBSERVED_BIRTH_DEATH_SOURCE =
+            """
+            Tree treeData = fromNewick(
+                "((A:1.0,B:1.0):1.0,(C:1.0,D:1.0):1.0);"
+            )
+
+            Tree tree ~ BirthDeath(
+                diversificationRate=0.5,
+                turnover=0.25,
+                samplingProbability=0.9,
+                taxa=taxa(treeData)
+            ) observed as treeData
+            """;
+
+    @Test
+    public void bindsYuleLikelihoodToFixedObservedTree() throws Exception {
+        BeastXModel model =
+                new PhyloSpecRunner(OBSERVED_YULE_SOURCE)
+                        .buildModel("observedYule");
+
+        assertTrue(model.beastState.treePriorDistributions.isEmpty());
+        assertEquals(1, model.beastState.observedTreeDistributions.size());
+
+        TreeModel observedTree =
+                model.beastState.observedTreeDistributions
+                        .keySet()
+                        .iterator()
+                        .next();
+
+        SpeciationLikelihood likelihood =
+                (SpeciationLikelihood) model.beastState.observedTreeDistributions
+                        .get(observedTree);
+
+        assertEquals("tree", observedTree.getId());
+        assertEquals("tree_likelihood", likelihood.getId());
+        assertSame(observedTree, likelihoodTree(likelihood));
+        assertTrue(Double.isFinite(likelihood.getLogLikelihood()));
+        assertEquals(1, model.likelihood.getLikelihoodCount());
+        assertSame(likelihood, model.likelihood.getLikelihood(0));
+    }
+
+    @Test
+    public void fixedObservedTreeDoesNotReceiveTreeOperators() throws Exception {
+        BeastXModel model =
+                new PhyloSpecRunner(OBSERVED_YULE_SOURCE)
+                        .buildModel("observedYuleOperators");
+
+        List<MCMCOperator> operators =
+                new OperatorBuilder().build(model.beastState);
+
+        assertEquals(1, operators.size(), "Only the sampled birth-rate parameter should receive an operator.");
+        assertFalse(
+                operators.stream().anyMatch(operator ->
+                        operator.getClass().getPackageName().contains("evomodel.operators")),
+                "A fixed observed tree must not receive tree operators."
+        );
+    }
+
+    @Test
+    public void runsDirectMCMCWithObservedTreeKeptFixed() throws Exception {
+        BeastXModel model =
+                new PhyloSpecRunner(OBSERVED_YULE_SOURCE)
+                        .buildModel("observedYuleDirectMCMC");
+
+        MCMC mcmc =
+                new MCMCBuilder(5).build(model);
+
+        assertEquals(1, mcmc.getOperatorSchedule().getOperatorCount());
+        mcmc.run();
+    }
+
+    @Test
+    public void bindsBirthDeathLikelihoodToFixedObservedTree() throws Exception {
+        BeastXModel model =
+                new PhyloSpecRunner(OBSERVED_BIRTH_DEATH_SOURCE)
+                        .buildModel("observedBirthDeath");
+
+        assertTrue(model.beastState.treePriorDistributions.isEmpty());
+        assertEquals(1, model.beastState.observedTreeDistributions.size());
+
+        TreeModel observedTree =
+                model.beastState.observedTreeDistributions
+                        .keySet()
+                        .iterator()
+                        .next();
+
+        SpeciationLikelihood likelihood =
+                (SpeciationLikelihood) model.beastState.observedTreeDistributions
+                        .get(observedTree);
+
+        assertSame(observedTree, likelihoodTree(likelihood));
+        assertTrue(Double.isFinite(likelihood.getLogLikelihood()));
+    }
+
+    @Test
+    public void exportsObservedYuleAsLikelihoodWithoutTreeOperators() throws Exception {
+        Path xmlPath =
+                XmlTestSupport.xmlPath("observedYuleTree");
+
+        XmlTestSupport.prepare(xmlPath);
+
+        String source =
+                OBSERVED_YULE_SOURCE
+                        + """
+
+                        mcmc {
+                            Integer chainLength = 5
+                            Integer randomSeed = 1234
+                            Logger screenLogger = screenLogger(
+                                logEvery=1,
+                                parameters=[birthRate]
+                            )
+                        }
+                        """;
+
+        BeastXModel model =
+                XmlTestSupport.buildModel("xmlObservedYuleTree", source);
+
+        String xml =
+                XmlTestSupport.writeXml(model, xmlPath);
+
+        XmlTestSupport.assertXmlContains(xml, "<newick id=\"tree_startingTree\"");
+        XmlTestSupport.assertXmlContains(xml, "<treeModel id=\"tree\">");
+        XmlTestSupport.assertXmlContains(xml, "<yuleModel id=\"tree_likelihood_model\"");
+        XmlTestSupport.assertXmlContains(xml, "<likelihood id=\"likelihood\">");
+        XmlTestSupport.assertXmlContains(xml, "<speciationLikelihood id=\"tree_likelihood\">");
+        XmlTestSupport.assertXmlDoesNotContain(xml, "<subtreeSlide");
+        XmlTestSupport.assertXmlDoesNotContain(xml, "<narrowExchange");
+        XmlTestSupport.assertXmlDoesNotContain(xml, "<wideExchange");
+        XmlTestSupport.assertXmlDoesNotContain(xml, "<wilsonBalding");
+
+        XmlTestSupport.runXml(xmlPath);
+    }
+
+    @Test
+    public void exportsObservedBirthDeathAsLikelihood() throws Exception {
+        Path xmlPath =
+                XmlTestSupport.xmlPath("observedBirthDeathTree");
+
+        XmlTestSupport.prepare(xmlPath);
+
+        String source =
+                """
+                Tree treeData = fromNewick(
+                    "((A:1.0,B:1.0):1.0,(C:1.0,D:1.0):1.0);"
+                )
+
+                PositiveReal diversificationRate ~ LogNormal(
+                    logMean=0.0,
+                    logSd=1.0
+                )
+
+                Tree tree ~ BirthDeath(
+                    diversificationRate=diversificationRate,
+                    turnover=0.25,
+                    samplingProbability=0.9,
+                    taxa=taxa(treeData)
+                ) observed as treeData
+
+                mcmc {
+                    Integer chainLength = 5
+                    Integer randomSeed = 1234
+                    Logger screenLogger = screenLogger(
+                        logEvery=1,
+                        parameters=[diversificationRate]
+                    )
+                }
+                """;
+
+        BeastXModel model =
+                XmlTestSupport.buildModel("xmlObservedBirthDeathTree", source);
+
+        String xml =
+                XmlTestSupport.writeXml(model, xmlPath);
+
+        XmlTestSupport.assertXmlContains(xml, "<birthDeathModel id=\"tree_likelihood_model\"");
+        XmlTestSupport.assertXmlContains(xml, "<speciationLikelihood id=\"tree_likelihood\">");
+        XmlTestSupport.assertXmlContains(xml, "<likelihood id=\"likelihood\">");
+        XmlTestSupport.assertXmlDoesNotContain(xml, "<subtreeSlide");
+        XmlTestSupport.assertXmlDoesNotContain(xml, "<narrowExchange");
+        XmlTestSupport.assertXmlDoesNotContain(xml, "<wideExchange");
+        XmlTestSupport.assertXmlDoesNotContain(xml, "<wilsonBalding");
+
+        XmlTestSupport.runXml(xmlPath);
+    }
+
+    private static TreeModel likelihoodTree(SpeciationLikelihood likelihood) throws Exception {
+        Field field =
+                SpeciationLikelihood.class.getDeclaredField("tree");
+
+        field.setAccessible(true);
+
+        return (TreeModel) field.get(likelihood);
+    }
+}

--- a/integrations/beastx/java/src/test/java/tiling/BeastXStateScriptFilesTest.java
+++ b/integrations/beastx/java/src/test/java/tiling/BeastXStateScriptFilesTest.java
@@ -142,7 +142,10 @@ public class BeastXStateScriptFilesTest {
                             .collect(Collectors.toSet());
 
             Set<String> actualTreeModelIds =
-                    beastState.treePriorDistributions.keySet().stream()
+                    Stream.concat(
+                                    beastState.treePriorDistributions.keySet().stream(),
+                                    beastState.observedTreeDistributions.keySet().stream()
+                            )
                             .map(TreeModel::getId)
                             .collect(Collectors.toSet());
 
@@ -157,7 +160,10 @@ public class BeastXStateScriptFilesTest {
                             .collect(Collectors.toSet());
 
             Set<String> actualLikelihoodIds =
-                    beastState.likelihoodDistributions.stream()
+                    Stream.concat(
+                                    beastState.likelihoodDistributions.stream(),
+                                    beastState.observedTreeDistributions.values().stream()
+                            )
                             .map(Likelihood::getId)
                             .collect(Collectors.toSet());
 

--- a/integrations/beastx/java/src/test/java/tiling/observations/observedAsTree.phylospec
+++ b/integrations/beastx/java/src/test/java/tiling/observations/observedAsTree.phylospec
@@ -1,0 +1,24 @@
+Tree treeData = fromNewick(
+    "((A:1.0,B:1.0):1.0,(C:1.0,D:1.0):1.0);"
+)
+
+PositiveReal birthRate ~ LogNormal(
+    logMean=0.0,
+    logSd=1.0
+)
+
+Tree tree ~ Yule(
+    birthRate=birthRate,
+    taxa=taxa(treeData)
+) observed as treeData
+
+// EXPECTED_TILES
+// TILING_SUCCESS
+// EXPECTED_TILES
+
+// EXPECTED BEASTX STATE
+// SN: birthRate
+// P: birthRate_prior
+// TM: tree
+// L: tree_likelihood
+// EXPECTED BEASTX STATE


### PR DESCRIPTION
## Summary

This PR adds BEAST X backend support for evaluating Yule and Birth–Death tree distributions on a fixed observed tree using PhyloSpec's `observed as` syntax.

For example:

```phylospec
Tree treeData = fromNewick(
    "((A:1.0,B:1.0):1.0,(C:1.0,D:1.0):1.0);"
)

Tree tree ~ Yule(
    birthRate=birthRate,
    taxa=taxa(treeData)
) observed as treeData
```

Previously, the BEAST X backend rejected this construction because `SpeciationLikelihood` receives its tree in its constructor and could not be rebound after construction. This prevented fixed-tree comparisons such as `testBirthDeathAsYule` from being represented consistently through a shared PhyloSpec source.

## Changes

- Added a dedicated `ObservedAsTreeTile`.
- Added deferred distribution construction to `BoundDistribution`.
- Updated the Yule and Birth–Death tiles so that `SpeciationLikelihood` is constructed after the final tree is known.
- Added a separate observed-tree distribution registry to `BeastXState`.
- Included observed tree densities in the model likelihood and posterior.
- Kept observed trees out of the sampled tree-prior collection.
- Prevented fixed observed trees from receiving tree operators.
- Added observed-tree support to direct model construction, XML export, XML validation, logger resolution, and model summaries.
- Added duplicate tree-name validation.
- Added regression tests and a PhyloSpec observed-tree fixture.

## Semantics

An observed tree distribution is treated as a likelihood evaluated on fixed tree data.

The observed tree:

- contributes its density to the posterior;
- is not registered as a sampled tree;
- does not receive subtree-slide, exchange, Wilson–Balding, node-height, or other tree operators;
- has consistent semantics in direct BEAST X execution and generated XML.

This follows the existing `observed as` likelihood classification used by the BEAST 3 backend.

## XML behaviour

For an observed Yule or Birth–Death distribution, the XML exporter now emits:

- the fixed Newick tree;
- the corresponding `treeModel`;
- the Yule or Birth–Death model;
- the `speciationLikelihood` inside the MCMC likelihood section.

It does not emit tree operators for the fixed observed tree.

The generated Yule and Birth–Death XML files were both parsed and executed successfully by BEAST X.

## Current scope

This PR supports:

- Yule distributions observed on a fixed tree;
- Birth–Death distributions observed on a fixed tree.

Other tree-distribution families, including Coalescent and Fossilized Birth–Death, have not yet been generalized to this binding mechanism. Unsupported observed tree-distribution types are rejected explicitly during XML validation rather than being exported with incorrect semantics.

## Validation

The complete BEAST X test suite was run with the BEAGLE native library available:

```text
Tests run: 398
Failures: 0
Errors: 0
Skipped: 0
BUILD SUCCESS
```

The new regression tests cover:

- binding Yule and Birth–Death likelihoods to the exact observed tree;
- inclusion of the observed tree density in the posterior likelihood;
- exclusion of the observed tree from sampled tree priors;
- absence of tree operators for the fixed tree;
- direct BEAST X MCMC construction and execution;
- Yule XML generation, parsing, and execution;
- Birth–Death XML generation, parsing, and execution;
- PhyloSpec tiling and BEAST X state expectations.

## Review notes

The main design points for review are:

1. Observed tree densities are classified under `likelihood`.
2. Fixed observed trees are kept separate from `treePriorDistributions`.
3. The current implementation is intentionally limited to Yule and Birth–Death before the mechanism is generalized to other tree-distribution families.