### PR TITLE
Fix Poisson distribution output type

### DIFF
--- a/core/java/src/main/resources/phylospec-core-component-library.json
+++ b/core/java/src/main/resources/phylospec-core-component-library.json
@@ -1368,7 +1368,7 @@
       },
       {
         "name": "Poisson",
-        "generatedType": "Distribution<NonNegativeReal>",
+        "generatedType": "Distribution<NonNegativeInteger>",
         "namespace": "phylospec.distributions",
         "description": "Poisson distribution",
         "arguments": [

--- a/core/java/src/test/java/org/phylospec/components/ComponentResolverTest.java
+++ b/core/java/src/test/java/org/phylospec/components/ComponentResolverTest.java
@@ -2,6 +2,7 @@ package org.phylospec.components;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 public class ComponentResolverTest {
@@ -16,5 +17,17 @@ public class ComponentResolverTest {
                 "Map<String, Vector<Real>>",
                 ComponentResolver.getUnqualifiedName(
                         "phylospec.types.Map<phylospec.types.String, phylospec.types.Vector<phylospec.types.Real>>"));
+    }
+
+    @Test
+    public void testPoissonGeneratesNonNegativeIntegers() throws IOException {
+        ComponentResolver resolver =
+                new ComponentResolver(ComponentResolver.loadCoreComponentLibraries());
+
+        Generator poisson = resolver.resolveGenerator("Poisson").getFirst();
+
+        assertEquals(
+                "phylospec.types.Distribution<phylospec.types.NonNegativeInteger>",
+                poisson.getGeneratedType());
     }
 }

--- a/tools/phylospec-template-gui/app/core-components.json
+++ b/tools/phylospec-template-gui/app/core-components.json
@@ -1368,7 +1368,7 @@
         },
         {
           "name": "Poisson",
-          "generatedType": "Distribution<NonNegativeReal>",
+          "generatedType": "Distribution<NonNegativeInteger>",
           "namespace": "phylospec.distributions",
           "description": "Poisson distribution",
           "arguments": [

--- a/website/src/lib/assets/core-components.json
+++ b/website/src/lib/assets/core-components.json
@@ -1317,7 +1317,7 @@
             },
             {
                 "name": "Poisson",
-                "generatedType": "Distribution<NonNegativeReal>",
+                "generatedType": "Distribution<NonNegativeInteger>",
                 "namespace": "phylospec.distributions",
                 "description": "Poisson distribution",
                 "arguments": [


### PR DESCRIPTION
## Summary

The core component metadata currently declares the Poisson distribution as producing `NonNegativeReal` values. Mathematically, a Poisson random variable represents a count and has support on the non-negative integers `{0, 1, 2, ...}`, rather than on the non-negative real numbers.

The BEAST 3 and BEAST X Poisson tiles already follow this definition by creating integer-valued state parameters.

This PR:

- changes the Poisson generated type from `Distribution<NonNegativeReal>` to `Distribution<NonNegativeInteger>`
- synchronizes the core, template GUI, and website component metadata
- adds a regression test for the resolved Poisson output type

The BEAST 3 and BEAST X Poisson tiles do not require changes because they already construct non-negative integer state parameters.

## Testing

```bash
mvn -pl integrations/beastx/java -am \
  -Djsonschema2pojo.skip=true \
  -Dtest=ComponentResolverTest,ScriptFilesTypesTest,TilingScriptFilesTest,BeastXStateScriptFilesTest,BeastXValidationParityTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test