### PR TITLE
Expand BEAST X operator selection

### DIFF
--- a/integrations/beastx/java/src/main/java/tiles/branchmodels/StrictClockTile.java
+++ b/integrations/beastx/java/src/main/java/tiles/branchmodels/StrictClockTile.java
@@ -39,7 +39,7 @@ public class StrictClockTile extends GeneratorTile<StrictClockBranchRates, Beast
         Parameter clockRateParameter =
                 BeastXParameters.toParameter(clockRate);
 
-        beastState.addTreeClockRateParameter(
+        beastState.addTreeStrictClockRateParameter(
                 tree,
                 clockRateParameter
         );

--- a/integrations/beastx/java/src/main/java/tiling/BeastXState.java
+++ b/integrations/beastx/java/src/main/java/tiling/BeastXState.java
@@ -52,17 +52,17 @@ public class BeastXState {
     public final List<AbstractDistributionLikelihood> calibrationPriorDistributions;
     public final List<Likelihood> likelihoodDistributions;
 
-    // Prior and likelihood components collected during tiling.
+    // Clock models associated with each tree.
     public final Map<TreeModel, List<Parameter>> treeClockRateParameters;
+    public final Map<TreeModel, List<Parameter>> treeStrictClockRateParameters;
     public final Map<TreeModel, RelaxedClockSpec> treeRelaxedClockModels;
 
-    // Clock models associated with each tree.
+    // Logger configuration collected from MCMC logger tiles.
     public final List<Logger> mcmcLoggers;
     public final List<ScreenLoggerSpec> screenLoggerSpecs;
     public final List<FileLoggerSpec> fileLoggerSpecs;
     public final List<TreeLoggerSpec> treeLoggerSpecs;
 
-    // Logger configuration collected from MCMC logger tiles.
     public final OperatorConfig operatorConfig;
     public final XmlPlan xmlPlan;
 
@@ -87,6 +87,7 @@ public class BeastXState {
         this.calibrationPriorDistributions = new ArrayList<>();
         this.likelihoodDistributions = new ArrayList<>();
         this.treeClockRateParameters = new HashMap<>();
+        this.treeStrictClockRateParameters = new HashMap<>();
         this.treeRelaxedClockModels = new HashMap<>();
         this.mcmcLoggers = new ArrayList<>();
         this.screenLoggerSpecs = new ArrayList<>();
@@ -242,6 +243,17 @@ public class BeastXState {
             Parameter clockRateParameter
     ) {
         this.treeClockRateParameters
+                .computeIfAbsent(treeModel, ignored -> new ArrayList<>())
+                .add(clockRateParameter);
+    }
+
+    // Records a strict-clock rate parameter and its general tree/clock association.
+    public void addTreeStrictClockRateParameter(
+            TreeModel treeModel,
+            Parameter clockRateParameter
+    ) {
+        addTreeClockRateParameter(treeModel, clockRateParameter);
+        this.treeStrictClockRateParameters
                 .computeIfAbsent(treeModel, ignored -> new ArrayList<>())
                 .add(clockRateParameter);
     }

--- a/integrations/beastx/java/src/main/java/tiling/BeastXState.java
+++ b/integrations/beastx/java/src/main/java/tiling/BeastXState.java
@@ -303,6 +303,8 @@ public class BeastXState {
         public double randomWalkWindowSize = 1.0;
 
         public double treeScaleWeight = 5.0;
+        public double treeRootScaleWeight = 5.0;
+        public double treeRootScaleFactor = 0.75;
         public double treeSubtreeSlideSize = 15.0;
         public double treeSubtreeSlideWeight = 15.0;
         public double treeNarrowExchangeWeight = 15.0;
@@ -319,6 +321,8 @@ public class BeastXState {
                 case "parameterScaleFactor" -> this.parameterScaleFactor = value;
                 case "randomWalkWindowSize" -> this.randomWalkWindowSize = value;
                 case "treeScaleWeight" -> this.treeScaleWeight = value;
+                case "treeRootScaleWeight" -> this.treeRootScaleWeight = value;
+                case "treeRootScaleFactor" -> this.treeRootScaleFactor = value;
                 case "treeSubtreeSlideSize" -> this.treeSubtreeSlideSize = value;
                 case "treeSubtreeSlideWeight" -> this.treeSubtreeSlideWeight = value;
                 case "treeNarrowExchangeWeight" -> this.treeNarrowExchangeWeight = value;
@@ -349,6 +353,7 @@ public class BeastXState {
             return Set.of(
                     "parameterOperatorWeight",
                     "treeScaleWeight",
+                    "treeRootScaleWeight",
                     "treeSubtreeSlideWeight",
                     "treeNarrowExchangeWeight",
                     "treeWideExchangeWeight",
@@ -364,7 +369,8 @@ public class BeastXState {
             return Set.of(
                     "parameterScaleFactor",
                     "treeClockUpDownScaleFactor",
-                    "treeScaleFactor"
+                    "treeScaleFactor",
+                    "treeRootScaleFactor"
             ).contains(settingName);
         }
 

--- a/integrations/beastx/java/src/main/java/tiling/operators/OperatorBuilder.java
+++ b/integrations/beastx/java/src/main/java/tiling/operators/OperatorBuilder.java
@@ -1,7 +1,6 @@
 package tiling.operators;
 
 import dr.evomodel.operators.ExchangeOperator;
-import dr.evomodel.operators.NodeHeightScaleOperator;
 import dr.evomodel.operators.RandomWalkNodeHeightOperator;
 import dr.evomodel.operators.SubtreeSlideOperator;
 import dr.evomodel.operators.UniformNodeHeightOperator;
@@ -86,11 +85,20 @@ public final class OperatorBuilder {
                 spec.parameter(), lower, upper, spec.weight(), (int) spec.tuning());
     }
 
-    private NodeHeightScaleOperator nodeHeightScaleOperator(OperatorSpec spec) {
-        NodeHeightScaleOperator operator = new NodeHeightScaleOperator(
-                spec.tree(), spec.tuning(), true, AdaptationMode.DEFAULT);
-        operator.setWeight(spec.weight());
-        return operator;
+    private ScaleOperator nodeHeightScaleOperator(OperatorSpec spec) {
+        DefaultTreeModel tree = defaultTree(spec);
+        Parameter nodeHeights = tree.createNodeHeightsParameter(true, true, false);
+        nodeHeights.setId(tree.getId() + ".allInternalNodeHeights");
+        return new ScaleOperator(
+                nodeHeights,
+                true,
+                0,
+                spec.tuning(),
+                AdaptationMode.DEFAULT,
+                spec.weight(),
+                null,
+                1.0,
+                false);
     }
 
     private ScaleOperator rootScaleOperator(OperatorSpec spec) {
@@ -132,7 +140,7 @@ public final class OperatorBuilder {
             case INTEGER_SWAP -> "SwapOperator(parameter=%s, weight=%s, size=%d)"
                     .formatted(parameter, spec.weight(), (int) spec.tuning());
             case INTEGER_UNIFORM -> integerUniformSummary(spec, parameter);
-            case TREE_NODE_HEIGHT_SCALE -> "NodeHeightScaleOperator(tree=%s, weight=%s, scaleFactor=%s, scaleAll=true)"
+            case TREE_NODE_HEIGHT_SCALE -> "ScaleOperator(treeNodeHeights=%s.allInternalNodeHeights, weight=%s, scaleFactor=%s, scaleAll=true)"
                     .formatted(tree, spec.weight(), spec.tuning());
             case TREE_ROOT_SCALE -> "ScaleOperator(treeRoot=%s.rootHeight, weight=%s, scaleFactor=%s)"
                     .formatted(tree, spec.weight(), spec.tuning());

--- a/integrations/beastx/java/src/main/java/tiling/operators/OperatorBuilder.java
+++ b/integrations/beastx/java/src/main/java/tiling/operators/OperatorBuilder.java
@@ -7,7 +7,6 @@ import dr.evomodel.operators.SubtreeSlideOperator;
 import dr.evomodel.operators.UniformNodeHeightOperator;
 import dr.evomodel.operators.WilsonBalding;
 import dr.evomodel.tree.DefaultTreeModel;
-import dr.evomodel.tree.TreeModel;
 import dr.inference.model.Bounds;
 import dr.inference.model.Parameter;
 import dr.inference.operators.AdaptationMode;
@@ -20,555 +19,168 @@ import dr.inference.operators.ScaleOperator;
 import dr.inference.operators.SwapOperator;
 import dr.inference.operators.UniformIntegerOperator;
 import dr.inference.operators.UpDownOperator;
-import org.phylospec.domain.NonNegativeReal;
-import org.phylospec.domain.PositiveReal;
-import org.phylospec.tiling.TypeToken;
-import org.phylospec.types.RealScalar;
-import org.phylospec.types.RealVector;
-import org.phylospec.types.Simplex;
 import tiling.BeastXState;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 
-/**
- * Builds MCMC operators for BEAST X state and tree parameters.
- */
-public class OperatorBuilder {
+/** Materializes selected operator specifications for direct BEAST X execution. */
+public final class OperatorBuilder {
 
-    private static final TypeToken<?> SIMPLEX =
-            new TypeToken<Simplex>() {};
-
-    private static final TypeToken<?> POSITIVE_REAL_SCALAR =
-            new TypeToken<RealScalar<? extends PositiveReal>>() {};
-
-    private static final TypeToken<?> POSITIVE_REAL_VECTOR =
-            new TypeToken<RealVector<? extends PositiveReal>>() {};
-
-    public List<MCMCOperator> build(BeastXState beastState) {
-        List<MCMCOperator> operators =
-                new ArrayList<>();
-
-        operators.addAll(buildParameterOperators(beastState));
-        operators.addAll(buildTreeOperators(beastState));
-        operators.addAll(buildTreeClockJointOperators(beastState));
-
-        return operators;
+    public List<MCMCOperator> build(BeastXState state) {
+        return selected(state).stream().map(this::build).toList();
     }
 
-    public List<String> summarize(BeastXState beastState) {
-        List<String> summaries =
-                new ArrayList<>();
-
-        summaries.addAll(summarizeParameterOperators(beastState));
-        summaries.addAll(summarizeTreeOperators(beastState));
-        summaries.addAll(summarizeTreeClockJointOperators(beastState));
-
-        return summaries;
+    public List<String> summarize(BeastXState state) {
+        return selected(state).stream().map(this::summarize).toList();
     }
 
-    private List<MCMCOperator> buildParameterOperators(BeastXState beastState) {
-        List<MCMCOperator> operators =
-                new ArrayList<>();
-
-        List<Map.Entry<Parameter, TypeToken<?>>> entries =
-                new ArrayList<>(beastState.stateNodes.entrySet());
-
-        entries.sort(Comparator.comparing(entry -> parameterId(entry.getKey())));
-
-        for (Map.Entry<Parameter, TypeToken<?>> entry : entries) {
-            Parameter parameter =
-                    entry.getKey();
-
-            if (isRelaxedClockRateCategoriesParameter(beastState, parameter)) {
-                operators.addAll(buildRelaxedClockCategoryOperators(parameter));
-            } else {
-                operators.add(buildParameterOperator(
-                        parameter,
-                        entry.getValue(),
-                        beastState.operatorConfig
-                ));
-            }
-        }
-
-        return operators;
+    private List<OperatorSpec> selected(BeastXState state) {
+        return new OperatorSelector().select(state).stream()
+                .filter(spec -> spec.weight() > 0.0)
+                .toList();
     }
 
-    private List<String> summarizeParameterOperators(BeastXState beastState) {
-        List<String> summaries =
-                new ArrayList<>();
-
-        List<Map.Entry<Parameter, TypeToken<?>>> entries =
-                new ArrayList<>(beastState.stateNodes.entrySet());
-
-        entries.sort(Comparator.comparing(entry -> parameterId(entry.getKey())));
-
-        for (Map.Entry<Parameter, TypeToken<?>> entry : entries) {
-            Parameter parameter =
-                    entry.getKey();
-
-            if (isRelaxedClockRateCategoriesParameter(beastState, parameter)) {
-                summaries.addAll(summarizeRelaxedClockCategoryOperators(parameter));
-            } else {
-                summaries.add(summarizeParameterOperator(
-                        parameter,
-                        entry.getValue(),
-                        beastState.operatorConfig
-                ));
-            }
-        }
-
-        return summaries;
+    private MCMCOperator build(OperatorSpec spec) {
+        return switch (spec.family()) {
+            case SCALE -> new ScaleOperator(
+                    spec.parameter(), spec.tuning(), AdaptationMode.DEFAULT, spec.weight());
+            case RANDOM_WALK -> new RandomWalkOperator(
+                    spec.parameter(), spec.tuning(),
+                    RandomWalkOperator.BoundaryCondition.reflecting,
+                    spec.weight(), AdaptationMode.DEFAULT);
+            case DELTA_EXCHANGE -> new DeltaExchangeOperator(
+                    spec.parameter(), null, spec.tuning(), spec.weight(), false,
+                    AdaptationMode.DEFAULT);
+            case INTEGER_RANDOM_WALK -> new RandomWalkIntegerOperator(
+                    spec.parameter(), (int) spec.tuning(), spec.weight());
+            case INTEGER_SWAP -> swapOperator(spec);
+            case INTEGER_UNIFORM -> uniformIntegerOperator(spec);
+            case TREE_NODE_HEIGHT_SCALE -> nodeHeightScaleOperator(spec);
+            case TREE_ROOT_SCALE -> rootScaleOperator(spec);
+            case TREE_UNIFORM_HEIGHT ->
+                    new UniformNodeHeightOperator(spec.tree(), spec.weight());
+            case TREE_RANDOM_WALK_HEIGHT -> new RandomWalkNodeHeightOperator(
+                    spec.tree(), spec.weight(), spec.tuning(),
+                    AdaptationMode.DEFAULT, 0.234);
+            case TREE_SUBTREE_SLIDE -> subtreeSlideOperator(spec);
+            case TREE_NARROW_EXCHANGE -> new ExchangeOperator(
+                    ExchangeOperator.NARROW, spec.tree(), spec.weight());
+            case TREE_WIDE_EXCHANGE -> new ExchangeOperator(
+                    ExchangeOperator.WIDE, spec.tree(), spec.weight());
+            case TREE_WILSON_BALDING -> new WilsonBalding(spec.tree(), spec.weight());
+            case TREE_CLOCK_UP_DOWN -> treeClockUpDownOperator(spec);
+        };
     }
 
-    private List<MCMCOperator> buildTreeOperators(BeastXState beastState) {
-        List<MCMCOperator> operators =
-                new ArrayList<>();
-
-        List<TreeModel> treeModels =
-                new ArrayList<>(beastState.treePriorDistributions.keySet());
-
-        treeModels.sort(Comparator.comparing(OperatorBuilder::treeId));
-
-        for (TreeModel treeModel : treeModels) {
-            operators.addAll(buildDefaultTreeOperators(
-                    treeModel,
-                    beastState.operatorConfig
-            ));
-        }
-
-        return operators;
-    }
-
-    private List<String> summarizeTreeOperators(BeastXState beastState) {
-        List<String> summaries =
-                new ArrayList<>();
-
-        List<TreeModel> treeModels =
-                new ArrayList<>(beastState.treePriorDistributions.keySet());
-
-        treeModels.sort(Comparator.comparing(OperatorBuilder::treeId));
-
-        for (TreeModel treeModel : treeModels) {
-            summaries.addAll(summarizeDefaultTreeOperators(
-                    treeModel,
-                    beastState.operatorConfig
-            ));
-        }
-
-        return summaries;
-    }
-
-    private List<MCMCOperator> buildTreeClockJointOperators(BeastXState beastState) {
-        List<MCMCOperator> operators =
-                new ArrayList<>();
-
-        if (beastState.operatorConfig.treeClockUpDownWeight <= 0.0) {
-            return operators;
-        }
-
-        List<Map.Entry<TreeModel, List<Parameter>>> entries =
-                new ArrayList<>(beastState.treeClockRateParameters.entrySet());
-
-        entries.sort(Comparator.comparing(entry -> treeId(entry.getKey())));
-
-        for (Map.Entry<TreeModel, List<Parameter>> entry : entries) {
-            TreeModel treeModel =
-                    entry.getKey();
-
-            if (!beastState.treePriorDistributions.containsKey(treeModel)) {
-                continue;
-            }
-
-            List<Parameter> clockRateParameters =
-                    new ArrayList<>(entry.getValue());
-
-            clockRateParameters.sort(Comparator.comparing(OperatorBuilder::parameterId));
-
-            for (Parameter clockRateParameter : clockRateParameters) {
-                TypeToken<?> typeToken =
-                        beastState.stateNodes.get(clockRateParameter);
-
-                if (typeToken != null && POSITIVE_REAL_SCALAR.isAssignableFrom(typeToken)) {
-                    operators.add(buildTreeClockUpDownOperator(
-                            treeModel,
-                            clockRateParameter,
-                            beastState.operatorConfig
-                    ));
-                }
-            }
-        }
-
-        return operators;
-    }
-
-    private List<String> summarizeTreeClockJointOperators(BeastXState beastState) {
-        List<String> summaries =
-                new ArrayList<>();
-
-        if (beastState.operatorConfig.treeClockUpDownWeight <= 0.0) {
-            return summaries;
-        }
-
-        List<Map.Entry<TreeModel, List<Parameter>>> entries =
-                new ArrayList<>(beastState.treeClockRateParameters.entrySet());
-
-        entries.sort(Comparator.comparing(entry -> treeId(entry.getKey())));
-
-        for (Map.Entry<TreeModel, List<Parameter>> entry : entries) {
-            TreeModel treeModel =
-                    entry.getKey();
-
-            if (!beastState.treePriorDistributions.containsKey(treeModel)) {
-                continue;
-            }
-
-            List<Parameter> clockRateParameters =
-                    new ArrayList<>(entry.getValue());
-
-            clockRateParameters.sort(Comparator.comparing(OperatorBuilder::parameterId));
-
-            for (Parameter clockRateParameter : clockRateParameters) {
-                TypeToken<?> typeToken =
-                        beastState.stateNodes.get(clockRateParameter);
-
-                if (typeToken != null && POSITIVE_REAL_SCALAR.isAssignableFrom(typeToken)) {
-                    summaries.add(summarizeTreeClockUpDownOperator(
-                            treeModel,
-                            clockRateParameter,
-                            beastState.operatorConfig
-                    ));
-                }
-            }
-        }
-
-        return summaries;
-    }
-
-    private MCMCOperator buildParameterOperator(
-            Parameter parameter,
-            TypeToken<?> typeToken,
-            BeastXState.OperatorConfig config
-    ) {
-        if (SIMPLEX.isAssignableFrom(typeToken)) {
-            return new DeltaExchangeOperator(
-                    parameter,
-                    config.parameterOperatorWeight
-            );
-        }
-
-        if (POSITIVE_REAL_SCALAR.isAssignableFrom(typeToken)
-                || POSITIVE_REAL_VECTOR.isAssignableFrom(typeToken)) {
-            return new ScaleOperator(
-                    parameter,
-                    config.parameterScaleFactor,
-                    AdaptationMode.DEFAULT,
-                    config.parameterOperatorWeight
-            );
-        }
-
-        return new RandomWalkOperator(
-                parameter,
-                config.randomWalkWindowSize,
-                RandomWalkOperator.BoundaryCondition.reflecting,
-                config.parameterOperatorWeight,
-                AdaptationMode.DEFAULT
-        );
-    }
-
-    private List<MCMCOperator> buildRelaxedClockCategoryOperators(
-            Parameter parameter
-    ) {
-        List<MCMCOperator> operators =
-                new ArrayList<>();
-
-        operators.add(new RandomWalkIntegerOperator(
-                parameter,
-                1,
-                10.0
-        ));
-
-        SwapOperator swapOperator =
-                new SwapOperator(parameter, 1);
-
-        swapOperator.setWeight(10.0);
-        operators.add(swapOperator);
-
-        Bounds<Double> bounds =
-                parameter.getBounds();
-
-        int lower =
-                (int) Math.ceil(bounds.getLowerLimit(0));
-
-        int upper =
-                (int) Math.floor(bounds.getUpperLimit(0));
-
-        operators.add(new UniformIntegerOperator(
-                parameter,
-                lower,
-                upper,
-                10.0,
-                1
-        ));
-
-        return operators;
-    }
-
-    private List<String> summarizeRelaxedClockCategoryOperators(
-            Parameter parameter
-    ) {
-        Bounds<Double> bounds =
-                parameter.getBounds();
-
-        int lower =
-                (int) Math.ceil(bounds.getLowerLimit(0));
-
-        int upper =
-                (int) Math.floor(bounds.getUpperLimit(0));
-
-        String id =
-                parameterId(parameter);
-
-        return List.of(
-                "RandomWalkIntegerOperator(parameter=%s, weight=10.0, windowSize=1)".formatted(id),
-                "SwapOperator(parameter=%s, weight=10.0, size=1)".formatted(id),
-                "UniformIntegerOperator(parameter=%s, weight=10.0, count=1, lower=%d, upper=%d)"
-                        .formatted(id, lower, upper)
-        );
-    }
-
-    private boolean isRelaxedClockRateCategoriesParameter(
-            BeastXState state,
-            Parameter parameter
-    ) {
-        return state.treeRelaxedClockModels
-                .values()
-                .stream()
-                .map(BeastXState.RelaxedClockSpec::rateCategoriesParameter)
-                .anyMatch(rateCategories ->
-                        rateCategories == parameter
-                                || parameterId(rateCategories).equals(parameterId(parameter))
-                );
-    }
-
-    private String summarizeParameterOperator(
-            Parameter parameter,
-            TypeToken<?> typeToken,
-            BeastXState.OperatorConfig config
-    ) {
-        if (SIMPLEX.isAssignableFrom(typeToken)) {
-            return "DeltaExchangeOperator(parameter=%s, weight=%s)".formatted(
-                    parameter.getId(),
-                    format(config.parameterOperatorWeight)
-            );
-        }
-
-        if (POSITIVE_REAL_SCALAR.isAssignableFrom(typeToken)
-                || POSITIVE_REAL_VECTOR.isAssignableFrom(typeToken)) {
-            return "ScaleOperator(parameter=%s, weight=%s, scaleFactor=%s)".formatted(
-                    parameter.getId(),
-                    format(config.parameterOperatorWeight),
-                    format(config.parameterScaleFactor)
-            );
-        }
-
-        return "RandomWalkOperator(parameter=%s, weight=%s, windowSize=%s, boundary=reflecting)".formatted(
-                parameter.getId(),
-                format(config.parameterOperatorWeight),
-                format(config.randomWalkWindowSize)
-        );
-    }
-
-    private List<MCMCOperator> buildDefaultTreeOperators(
-            TreeModel treeModel,
-            BeastXState.OperatorConfig config
-    ) {
-        List<MCMCOperator> operators =
-                new ArrayList<>();
-
-        operators.add(buildNodeHeightScaleOperator(
-                treeModel,
-                config
-        ));
-
-        operators.add(new UniformNodeHeightOperator(
-                treeModel,
-                config.treeUniformNodeHeightWeight
-        ));
-
-        operators.add(new RandomWalkNodeHeightOperator(
-                treeModel,
-                config.treeRandomWalkNodeHeightWeight,
-                config.treeRandomWalkNodeHeightSize,
-                AdaptationMode.DEFAULT,
-                0.234
-        ));
-
-        operators.add(new ExchangeOperator(
-                ExchangeOperator.NARROW,
-                treeModel,
-                config.treeNarrowExchangeWeight
-        ));
-
-        operators.add(new ExchangeOperator(
-                ExchangeOperator.WIDE,
-                treeModel,
-                config.treeWideExchangeWeight
-        ));
-
-        if (treeModel instanceof DefaultTreeModel defaultTreeModel) {
-            operators.add(new SubtreeSlideOperator(
-                    defaultTreeModel,
-                    config.treeSubtreeSlideSize,
-                    config.treeSubtreeSlideWeight,
-                    true,
-                    false,
-                    false,
-                    false,
-                    AdaptationMode.DEFAULT,
-                    0.234
-            ));
-        }
-
-        operators.add(new WilsonBalding(
-                treeModel,
-                config.treeWilsonBaldingWeight
-        ));
-
-        return operators;
-    }
-
-    private MCMCOperator buildNodeHeightScaleOperator(
-            TreeModel treeModel,
-            BeastXState.OperatorConfig config
-    ) {
-        NodeHeightScaleOperator operator =
-                new NodeHeightScaleOperator(
-                        treeModel,
-                        config.treeScaleFactor,
-                        true,
-                        AdaptationMode.DEFAULT
-                );
-
-        operator.setWeight(config.treeScaleWeight);
-
+    private SwapOperator swapOperator(OperatorSpec spec) {
+        SwapOperator operator = new SwapOperator(spec.parameter(), (int) spec.tuning());
+        operator.setWeight(spec.weight());
         return operator;
     }
 
-    private List<String> summarizeDefaultTreeOperators(
-            TreeModel treeModel,
-            BeastXState.OperatorConfig config
-    ) {
-        List<String> summaries =
-                new ArrayList<>();
-
-        summaries.add("NodeHeightScaleOperator(tree=%s, weight=%s, scaleFactor=%s, scaleAll=true)".formatted(
-                treeModel.getId(),
-                format(config.treeScaleWeight),
-                format(config.treeScaleFactor)
-        ));
-
-        summaries.add("UniformNodeHeightOperator(tree=%s, weight=%s)".formatted(
-                treeModel.getId(),
-                format(config.treeUniformNodeHeightWeight)
-        ));
-
-        summaries.add("RandomWalkNodeHeightOperator(tree=%s, weight=%s, size=%s)".formatted(
-                treeModel.getId(),
-                format(config.treeRandomWalkNodeHeightWeight),
-                format(config.treeRandomWalkNodeHeightSize)
-        ));
-
-        summaries.add("ExchangeOperator(tree=%s, mode=narrow, weight=%s)".formatted(
-                treeModel.getId(),
-                format(config.treeNarrowExchangeWeight)
-        ));
-
-        summaries.add("ExchangeOperator(tree=%s, mode=wide, weight=%s)".formatted(
-                treeModel.getId(),
-                format(config.treeWideExchangeWeight)
-        ));
-
-        if (treeModel instanceof DefaultTreeModel) {
-            summaries.add("SubtreeSlideOperator(tree=%s, weight=%s, size=%s)".formatted(
-                    treeModel.getId(),
-                    format(config.treeSubtreeSlideWeight),
-                    format(config.treeSubtreeSlideSize)
-            ));
-        }
-
-        summaries.add("WilsonBalding(tree=%s, weight=%s)".formatted(
-                treeModel.getId(),
-                format(config.treeWilsonBaldingWeight)
-        ));
-
-        return summaries;
+    private UniformIntegerOperator uniformIntegerOperator(OperatorSpec spec) {
+        Bounds<Double> bounds = requiredBounds(spec.parameter());
+        int lower = (int) Math.ceil(bounds.getLowerLimit(0));
+        int upper = (int) Math.floor(bounds.getUpperLimit(0));
+        return new UniformIntegerOperator(
+                spec.parameter(), lower, upper, spec.weight(), (int) spec.tuning());
     }
 
-    private MCMCOperator buildTreeClockUpDownOperator(
-            TreeModel treeModel,
-            Parameter clockRateParameter,
-            BeastXState.OperatorConfig config
-    ) {
-        if (!(treeModel instanceof DefaultTreeModel defaultTreeModel)) {
-            throw new IllegalArgumentException(
-                    "Tree-clock up/down operators require a DefaultTreeModel."
-            );
-        }
+    private NodeHeightScaleOperator nodeHeightScaleOperator(OperatorSpec spec) {
+        NodeHeightScaleOperator operator = new NodeHeightScaleOperator(
+                spec.tree(), spec.tuning(), true, AdaptationMode.DEFAULT);
+        operator.setWeight(spec.weight());
+        return operator;
+    }
 
-        Scalable[] up =
-                new Scalable[] {
-                        new Scalable.Default(clockRateParameter)
-                };
+    private ScaleOperator rootScaleOperator(OperatorSpec spec) {
+        DefaultTreeModel tree = defaultTree(spec);
+        Parameter rootHeight = tree.createNodeHeightsParameter(false, true, false);
+        rootHeight.setId(tree.getId() + ".rootHeight");
+        return new ScaleOperator(
+                rootHeight, spec.tuning(), AdaptationMode.DEFAULT, spec.weight());
+    }
 
-        Parameter allInternalNodeHeights =
-                defaultTreeModel.createNodeHeightsParameter(true, true, false);
-        allInternalNodeHeights.setId(treeModel.getId() + ".allInternalNodeHeights");
+    private SubtreeSlideOperator subtreeSlideOperator(OperatorSpec spec) {
+        return new SubtreeSlideOperator(
+                defaultTree(spec), spec.tuning(), spec.weight(),
+                true, false, false, false, AdaptationMode.DEFAULT, 0.234);
+    }
 
-        Scalable[] down =
-                new Scalable[] {
-                        new Scalable.Default(allInternalNodeHeights)
-                };
-
+    private UpDownOperator treeClockUpDownOperator(OperatorSpec spec) {
+        DefaultTreeModel tree = defaultTree(spec);
+        Parameter nodeHeights = tree.createNodeHeightsParameter(true, true, false);
+        nodeHeights.setId(tree.getId() + ".allInternalNodeHeights");
         return new UpDownOperator(
-                up,
-                down,
-                config.treeClockUpDownScaleFactor,
-                config.treeClockUpDownWeight,
-                AdaptationMode.DEFAULT
-        );
+                new Scalable[] {new Scalable.Default(spec.parameter())},
+                new Scalable[] {new Scalable.Default(nodeHeights)},
+                spec.tuning(), spec.weight(), AdaptationMode.DEFAULT);
     }
 
-    private String summarizeTreeClockUpDownOperator(
-            TreeModel treeModel,
-            Parameter clockRateParameter,
-            BeastXState.OperatorConfig config
-    ) {
-        return "UpDownOperator(up=[%s], down=[%s.allInternalNodeHeights], weight=%s, scaleFactor=%s)".formatted(
-                clockRateParameter.getId(),
-                treeModel.getId(),
-                format(config.treeClockUpDownWeight),
-                format(config.treeClockUpDownScaleFactor)
-        );
+    private String summarize(OperatorSpec spec) {
+        String parameter = spec.parameter() == null ? "" : parameterId(spec.parameter());
+        String tree = spec.tree() == null ? "" : treeId(spec);
+        return switch (spec.family()) {
+            case SCALE -> "ScaleOperator(parameter=%s, weight=%s, scaleFactor=%s)"
+                    .formatted(parameter, spec.weight(), spec.tuning());
+            case RANDOM_WALK -> "RandomWalkOperator(parameter=%s, weight=%s, windowSize=%s, boundary=reflecting)"
+                    .formatted(parameter, spec.weight(), spec.tuning());
+            case DELTA_EXCHANGE -> "DeltaExchangeOperator(parameter=%s, weight=%s)"
+                    .formatted(parameter, spec.weight());
+            case INTEGER_RANDOM_WALK -> "RandomWalkIntegerOperator(parameter=%s, weight=%s, windowSize=%d)"
+                    .formatted(parameter, spec.weight(), (int) spec.tuning());
+            case INTEGER_SWAP -> "SwapOperator(parameter=%s, weight=%s, size=%d)"
+                    .formatted(parameter, spec.weight(), (int) spec.tuning());
+            case INTEGER_UNIFORM -> integerUniformSummary(spec, parameter);
+            case TREE_NODE_HEIGHT_SCALE -> "NodeHeightScaleOperator(tree=%s, weight=%s, scaleFactor=%s, scaleAll=true)"
+                    .formatted(tree, spec.weight(), spec.tuning());
+            case TREE_ROOT_SCALE -> "ScaleOperator(treeRoot=%s.rootHeight, weight=%s, scaleFactor=%s)"
+                    .formatted(tree, spec.weight(), spec.tuning());
+            case TREE_UNIFORM_HEIGHT -> "UniformNodeHeightOperator(tree=%s, weight=%s)"
+                    .formatted(tree, spec.weight());
+            case TREE_RANDOM_WALK_HEIGHT -> "RandomWalkNodeHeightOperator(tree=%s, weight=%s, size=%s)"
+                    .formatted(tree, spec.weight(), spec.tuning());
+            case TREE_SUBTREE_SLIDE -> "SubtreeSlideOperator(tree=%s, weight=%s, size=%s)"
+                    .formatted(tree, spec.weight(), spec.tuning());
+            case TREE_NARROW_EXCHANGE -> "ExchangeOperator(tree=%s, mode=narrow, weight=%s)"
+                    .formatted(tree, spec.weight());
+            case TREE_WIDE_EXCHANGE -> "ExchangeOperator(tree=%s, mode=wide, weight=%s)"
+                    .formatted(tree, spec.weight());
+            case TREE_WILSON_BALDING -> "WilsonBalding(tree=%s, weight=%s)"
+                    .formatted(tree, spec.weight());
+            case TREE_CLOCK_UP_DOWN -> "UpDownOperator(up=[%s], down=[%s.allInternalNodeHeights], weight=%s, scaleFactor=%s)"
+                    .formatted(parameter, tree, spec.weight(), spec.tuning());
+        };
     }
 
-    private static String format(double value) {
-        return Double.toString(value);
+    private String integerUniformSummary(OperatorSpec spec, String parameter) {
+        Bounds<Double> bounds = requiredBounds(spec.parameter());
+        return "UniformIntegerOperator(parameter=%s, weight=%s, count=%d, lower=%d, upper=%d)"
+                .formatted(parameter, spec.weight(), (int) spec.tuning(),
+                        (int) Math.ceil(bounds.getLowerLimit(0)),
+                        (int) Math.floor(bounds.getUpperLimit(0)));
+    }
+
+    private static Bounds<Double> requiredBounds(Parameter parameter) {
+        Bounds<Double> bounds = parameter.getBounds();
+        if (bounds == null) {
+            throw new IllegalArgumentException("Integer uniform operators require bounds.");
+        }
+        return bounds;
+    }
+
+    private static DefaultTreeModel defaultTree(OperatorSpec spec) {
+        if (spec.tree() instanceof DefaultTreeModel tree) {
+            return tree;
+        }
+        throw new IllegalArgumentException("Operator requires a DefaultTreeModel.");
     }
 
     private static String parameterId(Parameter parameter) {
-        String id =
-                parameter.getId();
-
-        return id == null ? "" : id;
+        return parameter.getId() == null ? "" : parameter.getId();
     }
 
-    private static String treeId(TreeModel treeModel) {
-        String id =
-                treeModel.getId();
-
-        return id == null ? "" : id;
+    private static String treeId(OperatorSpec spec) {
+        return spec.tree().getId() == null ? "" : spec.tree().getId();
     }
 }

--- a/integrations/beastx/java/src/main/java/tiling/operators/OperatorSelector.java
+++ b/integrations/beastx/java/src/main/java/tiling/operators/OperatorSelector.java
@@ -23,6 +23,8 @@ import java.util.Map;
 /** Selects the common operator set used by direct and XML BEAST X output. */
 public final class OperatorSelector {
 
+    private static final double NO_TUNING = 0.0;
+
     private static final List<JointOperatorSelector> JOINT_SELECTORS =
             List.of(new StrictClockTreeUpDownOperatorSelector());
 
@@ -124,7 +126,7 @@ public final class OperatorSelector {
             }
             operators.add(treeOperator(
                     OperatorSpec.Family.TREE_UNIFORM_HEIGHT,
-                    tree, config.treeUniformNodeHeightWeight, 0.0));
+                    tree, config.treeUniformNodeHeightWeight, NO_TUNING));
             operators.add(treeOperator(
                     OperatorSpec.Family.TREE_RANDOM_WALK_HEIGHT,
                     tree, config.treeRandomWalkNodeHeightWeight,
@@ -136,13 +138,13 @@ public final class OperatorSelector {
             }
             operators.add(treeOperator(
                     OperatorSpec.Family.TREE_NARROW_EXCHANGE,
-                    tree, config.treeNarrowExchangeWeight, 0.0));
+                    tree, config.treeNarrowExchangeWeight, NO_TUNING));
             operators.add(treeOperator(
                     OperatorSpec.Family.TREE_WIDE_EXCHANGE,
-                    tree, config.treeWideExchangeWeight, 0.0));
+                    tree, config.treeWideExchangeWeight, NO_TUNING));
             operators.add(treeOperator(
                     OperatorSpec.Family.TREE_WILSON_BALDING,
-                    tree, config.treeWilsonBaldingWeight, 0.0));
+                    tree, config.treeWilsonBaldingWeight, NO_TUNING));
         }
         return operators;
     }

--- a/integrations/beastx/java/src/main/java/tiling/operators/OperatorSelector.java
+++ b/integrations/beastx/java/src/main/java/tiling/operators/OperatorSelector.java
@@ -1,0 +1,207 @@
+package tiling.operators;
+
+import dr.evomodel.tree.DefaultTreeModel;
+import dr.evomodel.tree.TreeModel;
+import dr.inference.model.Bounds;
+import dr.inference.model.Parameter;
+import org.phylospec.domain.PositiveReal;
+import org.phylospec.tiling.TypeToken;
+import org.phylospec.types.IntScalar;
+import org.phylospec.types.IntVector;
+import org.phylospec.types.RealScalar;
+import org.phylospec.types.RealVector;
+import org.phylospec.types.Simplex;
+import tiling.BeastXState;
+import tiling.operators.joint.JointOperatorSelector;
+import tiling.operators.joint.StrictClockTreeUpDownOperatorSelector;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/** Selects the common operator set used by direct and XML BEAST X output. */
+public final class OperatorSelector {
+
+    private static final List<JointOperatorSelector> JOINT_SELECTORS =
+            List.of(new StrictClockTreeUpDownOperatorSelector());
+
+    private static final TypeToken<?> SIMPLEX = new TypeToken<Simplex>() {};
+    private static final TypeToken<?> POSITIVE_REAL_SCALAR =
+            new TypeToken<RealScalar<? extends PositiveReal>>() {};
+    private static final TypeToken<?> POSITIVE_REAL_VECTOR =
+            new TypeToken<RealVector<? extends PositiveReal>>() {};
+    private static final TypeToken<?> INT_SCALAR =
+            new TypeToken<IntScalar<? extends org.phylospec.domain.Int>>() {};
+    private static final TypeToken<?> INT_VECTOR =
+            new TypeToken<IntVector<? extends org.phylospec.domain.Int>>() {};
+
+    public List<OperatorSpec> select(BeastXState state) {
+        List<OperatorSpec> operators = new ArrayList<>();
+        operators.addAll(selectParameterOperators(state));
+        operators.addAll(selectTreeOperators(state));
+        for (JointOperatorSelector selector : JOINT_SELECTORS) {
+            operators.addAll(selector.select(state));
+        }
+        return List.copyOf(operators);
+    }
+
+    private List<OperatorSpec> selectParameterOperators(BeastXState state) {
+        List<Map.Entry<Parameter, TypeToken<?>>> entries =
+                new ArrayList<>(state.stateNodes.entrySet());
+        entries.sort(Comparator.comparing(entry -> parameterId(entry.getKey())));
+
+        List<OperatorSpec> operators = new ArrayList<>();
+        for (Map.Entry<Parameter, TypeToken<?>> entry : entries) {
+            Parameter parameter = entry.getKey();
+            TypeToken<?> type = entry.getValue();
+
+            if (isRelaxedClockCategories(state, parameter)) {
+                operators.addAll(integerOperators(parameter, 10.0));
+            } else if (SIMPLEX.isAssignableFrom(type)) {
+                operators.add(parameterOperator(
+                        OperatorSpec.Family.DELTA_EXCHANGE,
+                        parameter,
+                        state.operatorConfig.parameterOperatorWeight,
+                        0.01));
+            } else if (isInteger(type)) {
+                operators.addAll(integerOperators(
+                        parameter,
+                        state.operatorConfig.parameterOperatorWeight));
+            } else if (hasFiniteBounds(parameter)) {
+                operators.add(parameterOperator(
+                        OperatorSpec.Family.RANDOM_WALK,
+                        parameter,
+                        state.operatorConfig.parameterOperatorWeight,
+                        state.operatorConfig.randomWalkWindowSize));
+            } else if (isPositive(type)) {
+                operators.add(parameterOperator(
+                        OperatorSpec.Family.SCALE,
+                        parameter,
+                        state.operatorConfig.parameterOperatorWeight,
+                        state.operatorConfig.parameterScaleFactor));
+            } else {
+                operators.add(parameterOperator(
+                        OperatorSpec.Family.RANDOM_WALK,
+                        parameter,
+                        state.operatorConfig.parameterOperatorWeight,
+                        state.operatorConfig.randomWalkWindowSize));
+            }
+        }
+        return operators;
+    }
+
+    private static List<OperatorSpec> integerOperators(Parameter parameter, double weight) {
+        List<OperatorSpec> operators = new ArrayList<>();
+        operators.add(parameterOperator(
+                OperatorSpec.Family.INTEGER_RANDOM_WALK, parameter, weight, 1.0));
+
+        if (parameter.getDimension() > 1) {
+            operators.add(parameterOperator(
+                    OperatorSpec.Family.INTEGER_SWAP, parameter, weight, 1.0));
+        }
+        if (hasFiniteBounds(parameter)) {
+            operators.add(parameterOperator(
+                    OperatorSpec.Family.INTEGER_UNIFORM, parameter, weight, 1.0));
+        }
+        return operators;
+    }
+
+    private List<OperatorSpec> selectTreeOperators(BeastXState state) {
+        List<TreeModel> trees = new ArrayList<>(state.treePriorDistributions.keySet());
+        trees.sort(Comparator.comparing(OperatorSelector::treeId));
+
+        List<OperatorSpec> operators = new ArrayList<>();
+        BeastXState.OperatorConfig config = state.operatorConfig;
+        for (TreeModel tree : trees) {
+            if (tree instanceof DefaultTreeModel) {
+                operators.add(treeOperator(
+                        OperatorSpec.Family.TREE_NODE_HEIGHT_SCALE,
+                        tree, config.treeScaleWeight, config.treeScaleFactor));
+                operators.add(treeOperator(
+                        OperatorSpec.Family.TREE_ROOT_SCALE,
+                        tree, config.treeRootScaleWeight, config.treeRootScaleFactor));
+            }
+            operators.add(treeOperator(
+                    OperatorSpec.Family.TREE_UNIFORM_HEIGHT,
+                    tree, config.treeUniformNodeHeightWeight, 0.0));
+            operators.add(treeOperator(
+                    OperatorSpec.Family.TREE_RANDOM_WALK_HEIGHT,
+                    tree, config.treeRandomWalkNodeHeightWeight,
+                    config.treeRandomWalkNodeHeightSize));
+            if (tree instanceof DefaultTreeModel) {
+                operators.add(treeOperator(
+                        OperatorSpec.Family.TREE_SUBTREE_SLIDE,
+                        tree, config.treeSubtreeSlideWeight, config.treeSubtreeSlideSize));
+            }
+            operators.add(treeOperator(
+                    OperatorSpec.Family.TREE_NARROW_EXCHANGE,
+                    tree, config.treeNarrowExchangeWeight, 0.0));
+            operators.add(treeOperator(
+                    OperatorSpec.Family.TREE_WIDE_EXCHANGE,
+                    tree, config.treeWideExchangeWeight, 0.0));
+            operators.add(treeOperator(
+                    OperatorSpec.Family.TREE_WILSON_BALDING,
+                    tree, config.treeWilsonBaldingWeight, 0.0));
+        }
+        return operators;
+    }
+
+    private static OperatorSpec parameterOperator(
+            OperatorSpec.Family family,
+            Parameter parameter,
+            double weight,
+            double tuning
+    ) {
+        return new OperatorSpec(family, parameter, null, weight, tuning);
+    }
+
+    private static OperatorSpec treeOperator(
+            OperatorSpec.Family family,
+            TreeModel tree,
+            double weight,
+            double tuning
+    ) {
+        return new OperatorSpec(family, null, tree, weight, tuning);
+    }
+
+    private static boolean isPositive(TypeToken<?> type) {
+        return type != null && (POSITIVE_REAL_SCALAR.isAssignableFrom(type)
+                || POSITIVE_REAL_VECTOR.isAssignableFrom(type));
+    }
+
+    private static boolean isInteger(TypeToken<?> type) {
+        return type != null && (INT_SCALAR.isAssignableFrom(type)
+                || INT_VECTOR.isAssignableFrom(type));
+    }
+
+    private static boolean hasFiniteBounds(Parameter parameter) {
+        Bounds<Double> bounds = parameter.getBounds();
+        if (bounds == null) {
+            return false;
+        }
+        for (int index = 0; index < parameter.getDimension(); index++) {
+            if (!Double.isFinite(bounds.getLowerLimit(index))
+                    || !Double.isFinite(bounds.getUpperLimit(index))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isRelaxedClockCategories(BeastXState state, Parameter parameter) {
+        String id = parameterId(parameter);
+        return state.treeRelaxedClockModels.values().stream()
+                .map(BeastXState.RelaxedClockSpec::rateCategoriesParameter)
+                .anyMatch(candidate -> candidate == parameter
+                        || (!id.isBlank() && id.equals(parameterId(candidate))));
+    }
+
+    static String parameterId(Parameter parameter) {
+        return parameter.getId() == null ? "" : parameter.getId();
+    }
+
+    static String treeId(TreeModel tree) {
+        return tree.getId() == null ? "" : tree.getId();
+    }
+}

--- a/integrations/beastx/java/src/main/java/tiling/operators/OperatorSpec.java
+++ b/integrations/beastx/java/src/main/java/tiling/operators/OperatorSpec.java
@@ -1,0 +1,40 @@
+package tiling.operators;
+
+import dr.evomodel.tree.TreeModel;
+import dr.inference.model.Parameter;
+
+/** Describes one selected BEAST X operator independently of its output form. */
+public record OperatorSpec(
+        Family family,
+        Parameter parameter,
+        TreeModel tree,
+        double weight,
+        double tuning
+) {
+    public enum Family {
+        SCALE,
+        RANDOM_WALK,
+        DELTA_EXCHANGE,
+        INTEGER_RANDOM_WALK,
+        INTEGER_SWAP,
+        INTEGER_UNIFORM,
+        TREE_NODE_HEIGHT_SCALE,
+        TREE_ROOT_SCALE,
+        TREE_UNIFORM_HEIGHT,
+        TREE_RANDOM_WALK_HEIGHT,
+        TREE_SUBTREE_SLIDE,
+        TREE_NARROW_EXCHANGE,
+        TREE_WIDE_EXCHANGE,
+        TREE_WILSON_BALDING,
+        TREE_CLOCK_UP_DOWN
+    }
+
+    public OperatorSpec {
+        if (family == null) {
+            throw new IllegalArgumentException("family must not be null.");
+        }
+        if (weight < 0.0) {
+            throw new IllegalArgumentException("weight must not be negative.");
+        }
+    }
+}

--- a/integrations/beastx/java/src/main/java/tiling/operators/joint/JointOperatorSelector.java
+++ b/integrations/beastx/java/src/main/java/tiling/operators/joint/JointOperatorSelector.java
@@ -1,0 +1,11 @@
+package tiling.operators.joint;
+
+import tiling.BeastXState;
+import tiling.operators.OperatorSpec;
+
+import java.util.List;
+
+/** Selects operators that jointly update multiple related state objects. */
+public interface JointOperatorSelector {
+    List<OperatorSpec> select(BeastXState state);
+}

--- a/integrations/beastx/java/src/main/java/tiling/operators/joint/StrictClockTreeUpDownOperatorSelector.java
+++ b/integrations/beastx/java/src/main/java/tiling/operators/joint/StrictClockTreeUpDownOperatorSelector.java
@@ -27,15 +27,14 @@ public final class StrictClockTreeUpDownOperatorSelector implements JointOperato
         }
 
         List<Map.Entry<TreeModel, List<Parameter>>> entries =
-                new ArrayList<>(state.treeClockRateParameters.entrySet());
+                new ArrayList<>(state.treeStrictClockRateParameters.entrySet());
         entries.sort(Comparator.comparing(entry -> treeId(entry.getKey())));
 
         List<OperatorSpec> operators = new ArrayList<>();
         for (Map.Entry<TreeModel, List<Parameter>> entry : entries) {
             TreeModel tree = entry.getKey();
             if (!(tree instanceof DefaultTreeModel)
-                    || !state.treePriorDistributions.containsKey(tree)
-                    || state.treeRelaxedClockModels.containsKey(tree)) {
+                    || !state.treePriorDistributions.containsKey(tree)) {
                 continue;
             }
 

--- a/integrations/beastx/java/src/main/java/tiling/operators/joint/StrictClockTreeUpDownOperatorSelector.java
+++ b/integrations/beastx/java/src/main/java/tiling/operators/joint/StrictClockTreeUpDownOperatorSelector.java
@@ -1,0 +1,77 @@
+package tiling.operators.joint;
+
+import dr.evomodel.tree.DefaultTreeModel;
+import dr.evomodel.tree.TreeModel;
+import dr.inference.model.Parameter;
+import org.phylospec.domain.PositiveReal;
+import org.phylospec.tiling.TypeToken;
+import org.phylospec.types.RealScalar;
+import tiling.BeastXState;
+import tiling.operators.OperatorSpec;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/** Selects joint tree/clock moves for stochastic strict-clock models. */
+public final class StrictClockTreeUpDownOperatorSelector implements JointOperatorSelector {
+
+    private static final TypeToken<?> POSITIVE_REAL_SCALAR =
+            new TypeToken<RealScalar<? extends PositiveReal>>() {};
+
+    @Override
+    public List<OperatorSpec> select(BeastXState state) {
+        if (state.operatorConfig.treeClockUpDownWeight <= 0.0) {
+            return List.of();
+        }
+
+        List<Map.Entry<TreeModel, List<Parameter>>> entries =
+                new ArrayList<>(state.treeClockRateParameters.entrySet());
+        entries.sort(Comparator.comparing(entry -> treeId(entry.getKey())));
+
+        List<OperatorSpec> operators = new ArrayList<>();
+        for (Map.Entry<TreeModel, List<Parameter>> entry : entries) {
+            TreeModel tree = entry.getKey();
+            if (!(tree instanceof DefaultTreeModel)
+                    || !state.treePriorDistributions.containsKey(tree)
+                    || state.treeRelaxedClockModels.containsKey(tree)) {
+                continue;
+            }
+
+            entry.getValue().stream()
+                    .distinct()
+                    .sorted(Comparator.comparing(StrictClockTreeUpDownOperatorSelector::parameterId))
+                    .filter(parameter -> isPositiveClockRate(state, parameter))
+                    .map(parameter -> new OperatorSpec(
+                            OperatorSpec.Family.TREE_CLOCK_UP_DOWN,
+                            parameter,
+                            tree,
+                            state.operatorConfig.treeClockUpDownWeight,
+                            state.operatorConfig.treeClockUpDownScaleFactor))
+                    .forEach(operators::add);
+        }
+        return List.copyOf(operators);
+    }
+
+    private static boolean isPositiveClockRate(BeastXState state, Parameter parameter) {
+        TypeToken<?> type = state.stateNodes.get(parameter);
+        if (type == null) {
+            String id = parameterId(parameter);
+            type = state.stateNodes.entrySet().stream()
+                    .filter(entry -> !id.isBlank() && id.equals(parameterId(entry.getKey())))
+                    .map(Map.Entry::getValue)
+                    .findFirst()
+                    .orElse(null);
+        }
+        return type != null && POSITIVE_REAL_SCALAR.isAssignableFrom(type);
+    }
+
+    private static String parameterId(Parameter parameter) {
+        return parameter.getId() == null ? "" : parameter.getId();
+    }
+
+    private static String treeId(TreeModel tree) {
+        return tree.getId() == null ? "" : tree.getId();
+    }
+}

--- a/integrations/beastx/java/src/main/java/tiling/xml/builders/OperatorXmlBuilder.java
+++ b/integrations/beastx/java/src/main/java/tiling/xml/builders/OperatorXmlBuilder.java
@@ -1,518 +1,149 @@
 package tiling.xml.builders;
 
 import dr.evomodel.tree.TreeModel;
-import dr.inference.model.Bounds;
 import dr.inference.model.Parameter;
 import tiling.BeastXState;
+import tiling.operators.OperatorSelector;
+import tiling.operators.OperatorSpec;
 import tiling.xml.XmlElement;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
-/**
- * Builds XML operator definitions from the operators implied by a BEAST X state.
- */
-public class OperatorXmlBuilder {
+/** Materializes the shared operator selection as BEAST X XML. */
+public final class OperatorXmlBuilder {
 
     public List<XmlElement> buildOperators(BeastXState state) {
-        List<XmlElement> operators =
-                new ArrayList<>();
-
-        operators.addAll(buildParameterOperators(state));
-        operators.addAll(buildTreeOperators(state));
-        operators.addAll(buildClockTreeUpDownOperators(state));
-
-        return operators;
+        return new OperatorSelector().select(state).stream()
+                .filter(spec -> spec.weight() > 0.0)
+                .map(this::build)
+                .toList();
     }
 
-    private List<XmlElement> buildParameterOperators(BeastXState state) {
-        List<XmlElement> operators =
-                new ArrayList<>();
-
-        List<Parameter> parameters =
-                new ArrayList<>(state.stateNodes.keySet());
-
-        parameters.removeIf(parameter -> isRelaxedClockRateCategoriesParameter(state, parameter));
-
-        parameters.sort(Comparator.comparing(OperatorXmlBuilder::parameterId));
-
-        for (Parameter parameter : parameters) {
-            if (isSimplexParameter(parameter)) {
-                operators.add(deltaExchangeOperator(state, parameter));
-            } else if (hasFiniteLowerAndUpperBounds(parameter)) {
-                operators.add(randomWalkOperator(state, parameter));
-            } else if (supportsScaleOperator(parameter)) {
-                operators.add(scaleOperator(state, parameter));
-            } else {
-                operators.add(randomWalkOperator(state, parameter));
-            }
-        }
-
-        return operators;
+    private XmlElement build(OperatorSpec spec) {
+        return switch (spec.family()) {
+            case SCALE -> parameterOperator(
+                    "scaleOperator", spec, "scale",
+                    "scaleFactor", format(spec.tuning()));
+            case RANDOM_WALK -> parameterOperator(
+                    "randomWalkOperator", spec, "randomWalk",
+                    "windowSize", format(spec.tuning()))
+                    .withAttribute("boundaryCondition", "reflecting");
+            case DELTA_EXCHANGE -> parameterOperator(
+                    "deltaExchange", spec, "deltaExchange",
+                    "delta", format(spec.tuning()));
+            case INTEGER_RANDOM_WALK -> parameterOperator(
+                    "randomWalkIntegerOperator", spec, "randomWalk",
+                    "windowSize", Integer.toString((int) spec.tuning()));
+            case INTEGER_SWAP -> parameterOperator(
+                    "swapOperator", spec, "swap",
+                    "size", Integer.toString((int) spec.tuning()))
+                    .withAttribute("autoOptimize", "false");
+            case INTEGER_UNIFORM -> parameterOperator(
+                    "uniformIntegerOperator", spec, "uniform",
+                    "count", Integer.toString((int) spec.tuning()));
+            case TREE_NODE_HEIGHT_SCALE -> nodeHeightScaleOperator(spec);
+            case TREE_ROOT_SCALE -> rootScaleOperator(spec);
+            case TREE_UNIFORM_HEIGHT -> treeOperator(
+                    "nodeHeightOperator", spec, "uniformNodeHeight")
+                    .withAttribute("type", "uniform");
+            case TREE_RANDOM_WALK_HEIGHT -> treeOperator(
+                    "nodeHeightOperator", spec, "randomWalkNodeHeight")
+                    .withAttribute("type", "randomwalk")
+                    .withAttribute("size", format(spec.tuning()))
+                    .withAttribute("autoOptimize", "true");
+            case TREE_SUBTREE_SLIDE -> treeOperator(
+                    "subtreeSlide", spec, "subtreeSlide")
+                    .withAttribute("size", format(spec.tuning()))
+                    .withAttribute("gaussian", "true");
+            case TREE_NARROW_EXCHANGE -> treeOperator(
+                    "narrowExchange", spec, "narrowExchange");
+            case TREE_WIDE_EXCHANGE -> treeOperator(
+                    "wideExchange", spec, "wideExchange");
+            case TREE_WILSON_BALDING -> treeOperator(
+                    "wilsonBalding", spec, "wilsonBalding");
+            case TREE_CLOCK_UP_DOWN -> treeClockUpDownOperator(spec);
+        };
     }
 
-    private List<XmlElement> buildClockTreeUpDownOperators(BeastXState state) {
-        List<XmlElement> operators =
-                new ArrayList<>();
-
-        Parameter clockRate =
-                findClockRateParameter(state);
-
-        if (clockRate == null) {
-            return operators;
-        }
-
-        List<TreeModel> trees =
-                new ArrayList<>(state.treePriorDistributions.keySet());
-
-        trees.sort(Comparator.comparing(OperatorXmlBuilder::treeId));
-
-        for (TreeModel treeModel : trees) {
-            if (hasRelaxedClockBranchRateModel(state, treeModel)) {
-                continue;
-            }
-
-            operators.add(
-                    clockTreeUpDownOperator(
-                            state,
-                            clockRate,
-                            treeModel
-                    )
-            );
-        }
-
-        return operators;
-    }
-
-    private List<XmlElement> buildTreeOperators(BeastXState state) {
-        List<XmlElement> operators =
-                new ArrayList<>();
-
-        List<TreeModel> trees =
-                new ArrayList<>(state.treePriorDistributions.keySet());
-
-        trees.sort(Comparator.comparing(OperatorXmlBuilder::treeId));
-
-        for (TreeModel treeModel : trees) {
-            if (hasRelaxedClockBranchRateModel(state, treeModel)) {
-                continue;
-            }
-
-            String id =
-                    treeId(treeModel);
-
-            operators.add(
-                    nodeHeightScaleOperator(state, treeModel)
-            );
-
-            operators.add(
-                    uniformNodeHeightOperator(state, treeModel)
-            );
-
-            operators.add(
-                    randomWalkNodeHeightOperator(state, treeModel)
-            );
-
-            operators.add(
-                    treeOperator(
-                            "narrowExchange",
-                            id + "_narrowExchange",
-                            state.operatorConfig.treeNarrowExchangeWeight,
-                            treeModel
-                    )
-            );
-
-            operators.add(
-                    treeOperator(
-                            "wideExchange",
-                            id + "_wideExchange",
-                            state.operatorConfig.treeWideExchangeWeight,
-                            treeModel
-                    )
-            );
-
-            operators.add(
-                    subtreeSlideOperator(state, treeModel)
-            );
-
-            operators.add(
-                    treeOperator(
-                            "wilsonBalding",
-                            id + "_wilsonBalding",
-                            state.operatorConfig.treeWilsonBaldingWeight,
-                            treeModel
-                    )
-            );
-        }
-
-        return operators;
-    }
-
-    private XmlElement nodeHeightScaleOperator(
-            BeastXState state,
-            TreeModel treeModel
+    private XmlElement parameterOperator(
+            String element,
+            OperatorSpec spec,
+            String suffix,
+            String tuningName,
+            String tuningValue
     ) {
-        String id =
-                treeId(treeModel);
-
-        return XmlElement.element("nodeHeightScaleOperator")
-                .withId(id + "_nodeHeightScale")
-                .withAttribute("scaleFactor", format(state.operatorConfig.treeScaleFactor))
-                .withAttribute("weight", format(state.operatorConfig.treeScaleWeight))
-                .withAttribute("scaleAll", "true")
-                .withAttribute("autoOptimize", "true")
-                .withChild(XmlElement.ref("treeModel", id));
+        return XmlElement.element(element)
+                .withId(parameterId(spec.parameter()) + "_" + suffix)
+                .withAttribute(tuningName, tuningValue)
+                .withAttribute("weight", format(spec.weight()))
+                .withChild(parameterReference(spec.parameter()));
     }
 
-    private XmlElement uniformNodeHeightOperator(
-            BeastXState state,
-            TreeModel treeModel
-    ) {
-        String id =
-                treeId(treeModel);
-
-        return XmlElement.element("nodeHeightOperator")
-                .withId(id + "_uniformNodeHeight")
-                .withAttribute("type", "uniform")
-                .withAttribute("weight", format(state.operatorConfig.treeUniformNodeHeightWeight))
-                .withChild(treeReference(treeModel));
-    }
-
-    private XmlElement randomWalkNodeHeightOperator(
-            BeastXState state,
-            TreeModel treeModel
-    ) {
-        String id =
-                treeId(treeModel);
-
-        return XmlElement.element("nodeHeightOperator")
-                .withId(id + "_randomWalkNodeHeight")
-                .withAttribute("type", "randomwalk")
-                .withAttribute("size", format(state.operatorConfig.treeRandomWalkNodeHeightSize))
-                .withAttribute("weight", format(state.operatorConfig.treeRandomWalkNodeHeightWeight))
-                .withAttribute("autoOptimize", "true")
-                .withChild(treeReference(treeModel));
-    }
-
-    private boolean isRelaxedClockRateCategoriesParameter(
-            BeastXState state,
-            Parameter parameter
-    ) {
-        String parameterId =
-                parameter.getId();
-
-        for (BeastXState.RelaxedClockSpec spec : state.treeRelaxedClockModels.values()) {
-            Parameter rateCategoriesParameter =
-                    spec.rateCategoriesParameter();
-
-            if (rateCategoriesParameter == parameter) {
-                return true;
-            }
-
-            String rateCategoriesParameterId =
-                    rateCategoriesParameter.getId();
-
-            if (
-                    parameterId != null
-                            && rateCategoriesParameterId != null
-                            && parameterId.equals(rateCategoriesParameterId)
-            ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private boolean hasRelaxedClockBranchRateModel(
-            BeastXState state,
-            TreeModel treeModel
-    ) {
-        if (state.treeRelaxedClockModels.containsKey(treeModel)) {
-            return true;
-        }
-
-        String treeModelId =
-                treeId(treeModel);
-
-        for (TreeModel registeredTreeModel : state.treeRelaxedClockModels.keySet()) {
-            if (treeModelId.equals(treeId(registeredTreeModel))) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private XmlElement scaleOperator(
-            BeastXState state,
-            Parameter parameter
-    ) {
-        String id =
-                parameterId(parameter);
-
+    private XmlElement nodeHeightScaleOperator(OperatorSpec spec) {
+        String treeId = treeId(spec.tree());
         return XmlElement.element("scaleOperator")
-                .withId(id + "_scale")
-                .withAttribute("scaleFactor", format(state.operatorConfig.parameterScaleFactor))
-                .withAttribute("weight", format(state.operatorConfig.parameterOperatorWeight))
-                .withChild(parameterReference(parameter));
+                .withId(treeId + "_scale")
+                .withAttribute("scaleFactor", format(spec.tuning()))
+                .withAttribute("weight", format(spec.weight()))
+                .withAttribute("scaleAll", "true")
+                .withAttribute("ignoreBounds", "true")
+                .withChild(XmlElement.ref(
+                        "parameter", treeId + ".allInternalNodeHeights"));
     }
 
-    private XmlElement randomWalkOperator(
-            BeastXState state,
-            Parameter parameter
-    ) {
-        String id =
-                parameterId(parameter);
-
-        return XmlElement.element("randomWalkOperator")
-                .withId(id + "_randomWalk")
-                .withAttribute("windowSize", format(state.operatorConfig.randomWalkWindowSize))
-                .withAttribute("weight", format(state.operatorConfig.parameterOperatorWeight))
-                .withAttribute("boundaryCondition", "reflecting")
-                .withChild(parameterReference(parameter));
+    private XmlElement rootScaleOperator(OperatorSpec spec) {
+        String treeId = treeId(spec.tree());
+        return XmlElement.element("scaleOperator")
+                .withId(treeId + "_rootScale")
+                .withAttribute("scaleFactor", format(spec.tuning()))
+                .withAttribute("weight", format(spec.weight()))
+                .withChild(XmlElement.ref("parameter", treeId + ".rootHeight"));
     }
 
-    private XmlElement deltaExchangeOperator(
-            BeastXState state,
-            Parameter parameter
-    ) {
-        String id =
-                parameterId(parameter);
-
-        return XmlElement.element("deltaExchange")
-                .withId(id + "_deltaExchange")
-                .withAttribute("delta", "0.01")
-                .withAttribute("weight", format(state.operatorConfig.parameterOperatorWeight))
-                .withChild(parameterReference(parameter));
+    private XmlElement treeOperator(String element, OperatorSpec spec, String suffix) {
+        return XmlElement.element(element)
+                .withId(treeId(spec.tree()) + "_" + suffix)
+                .withAttribute("weight", format(spec.weight()))
+                .withChild(treeReference(spec.tree()));
     }
 
-    private XmlElement clockTreeUpDownOperator(
-            BeastXState state,
-            Parameter clockRate,
-            TreeModel treeModel
-    ) {
-        String treeId =
-                treeId(treeModel);
-
-        String clockRateId =
-                parameterId(clockRate);
-
+    private XmlElement treeClockUpDownOperator(OperatorSpec spec) {
+        String treeId = treeId(spec.tree());
         return XmlElement.element("upDownOperator")
-                .withId(treeId + "_" + clockRateId + "_upDown")
-                .withAttribute("scaleFactor", format(state.operatorConfig.treeClockUpDownScaleFactor))
-                .withAttribute("weight", format(state.operatorConfig.treeClockUpDownWeight))
-                .withChild(
-                        XmlElement.element("up")
-                                .withChild(parameterReference(clockRate))
-                )
-                .withChild(
-                        XmlElement.element("down")
-                                .withChild(treeAllInternalNodeHeightsReference(treeModel))
-                );
-    }
-
-    private XmlElement treeOperator(
-            String elementName,
-            String id,
-            double weight,
-            TreeModel treeModel
-    ) {
-        return XmlElement.element(elementName)
-                .withId(id)
-                .withAttribute("weight", format(weight))
-                .withChild(treeReference(treeModel));
-    }
-
-    private XmlElement subtreeSlideOperator(
-            BeastXState state,
-            TreeModel treeModel
-    ) {
-        String id =
-                treeId(treeModel);
-
-        return XmlElement.element("subtreeSlide")
-                .withId(id + "_subtreeSlide")
-                .withAttribute("weight", format(state.operatorConfig.treeSubtreeSlideWeight))
-                .withAttribute("size", format(state.operatorConfig.treeSubtreeSlideSize))
-                .withAttribute("gaussian", "true")
-                .withChild(treeReference(treeModel));
-    }
-
-    private Parameter findClockRateParameter(BeastXState state) {
-        List<Parameter> parameters =
-                new ArrayList<>(state.stateNodes.keySet());
-
-        parameters.removeIf(parameter -> isRelaxedClockRateCategoriesParameter(state, parameter));
-
-        parameters.sort(Comparator.comparing(OperatorXmlBuilder::parameterId));
-
-        for (Parameter parameter : parameters) {
-            String id =
-                    parameterId(parameter);
-
-            if ("clockRate".equals(id)) {
-                return parameter;
-            }
-        }
-
-        for (Parameter parameter : parameters) {
-            String id =
-                    parameterId(parameter);
-
-            if ("clock.rate".equals(id)) {
-                return parameter;
-            }
-        }
-
-        for (Parameter parameter : parameters) {
-            String id =
-                    parameterId(parameter)
-                            .toLowerCase();
-
-            if (id.contains("clockrate") || id.contains("clock.rate")) {
-                return parameter;
-            }
-        }
-
-        return null;
+                .withId(treeId + "_" + parameterId(spec.parameter()) + "_upDown")
+                .withAttribute("scaleFactor", format(spec.tuning()))
+                .withAttribute("weight", format(spec.weight()))
+                .withChild(XmlElement.element("up")
+                        .withChild(parameterReference(spec.parameter())))
+                .withChild(XmlElement.element("down")
+                        .withChild(XmlElement.ref(
+                                "parameter", treeId + ".allInternalNodeHeights")));
     }
 
     private XmlElement parameterReference(Parameter parameter) {
         return XmlElement.ref("parameter", parameterId(parameter));
     }
 
-    private XmlElement treeReference(TreeModel treeModel) {
-        return XmlElement.ref("treeModel", treeId(treeModel));
-    }
-
-    private XmlElement treeAllInternalNodeHeightsReference(TreeModel treeModel) {
-        return XmlElement.ref(
-                "parameter",
-                treeId(treeModel) + ".allInternalNodeHeights"
-        );
-    }
-
-    private static boolean supportsScaleOperator(Parameter parameter) {
-        Bounds<Double> bounds =
-                parameter.getBounds();
-
-        if (bounds == null) {
-            return false;
-        }
-
-        boolean strictlyPositive =
-                true;
-
-        boolean strictlyNegative =
-                true;
-
-        for (int i = 0; i < parameter.getDimension(); i++) {
-            double lower =
-                    bounds.getLowerLimit(i);
-
-            double upper =
-                    bounds.getUpperLimit(i);
-
-            double value =
-                    parameter.getParameterValue(i);
-
-            if (!(lower >= 0.0 && value > 0.0)) {
-                strictlyPositive =
-                        false;
-            }
-
-            if (!(upper <= 0.0 && value < 0.0)) {
-                strictlyNegative =
-                        false;
-            }
-        }
-
-        return strictlyPositive || strictlyNegative;
-    }
-
-    private static boolean hasFiniteLowerAndUpperBounds(Parameter parameter) {
-        Bounds<Double> bounds =
-                parameter.getBounds();
-
-        if (bounds == null) {
-            return false;
-        }
-
-        double lower =
-                bounds.getLowerLimit(0);
-
-        double upper =
-                bounds.getUpperLimit(0);
-
-        return Double.isFinite(lower) && Double.isFinite(upper);
-    }
-
-    private static boolean isSimplexParameter(Parameter parameter) {
-        if (parameter.getDimension() <= 1) {
-            return false;
-        }
-
-        Bounds<Double> bounds =
-                parameter.getBounds();
-
-        if (bounds == null) {
-            return false;
-        }
-
-        double sum =
-                0.0;
-
-        for (int i = 0; i < parameter.getDimension(); i++) {
-            double lower =
-                    bounds.getLowerLimit(i);
-
-            double upper =
-                    bounds.getUpperLimit(i);
-
-            if (!approximatelyZero(lower) || !approximatelyOne(upper)) {
-                return false;
-            }
-
-            sum += parameter.getParameterValue(i);
-        }
-
-        return approximatelyOne(sum);
-    }
-
-    private static boolean approximatelyZero(double value) {
-        return Math.abs(value) < 1.0e-12;
-    }
-
-    private static boolean approximatelyOne(double value) {
-        return Math.abs(value - 1.0) < 1.0e-12;
+    private XmlElement treeReference(TreeModel tree) {
+        return XmlElement.ref("treeModel", treeId(tree));
     }
 
     private static String parameterId(Parameter parameter) {
-        String id =
-                parameter.getId();
-
+        String id = parameter.getId();
         if (id == null || id.isBlank()) {
-            id =
-                    parameter.getParameterName();
+            id = parameter.getParameterName();
         }
-
         if (id == null || id.isBlank()) {
             throw new IllegalArgumentException("Cannot serialize unnamed BEAST X parameter.");
         }
-
         return id;
     }
 
-    private static String treeId(TreeModel treeModel) {
-        String id =
-                treeModel.getId();
-
+    private static String treeId(TreeModel tree) {
+        String id = tree.getId();
         if (id == null || id.isBlank()) {
             throw new IllegalArgumentException("Cannot serialize unnamed BEAST X tree model.");
         }
-
         return id;
     }
 
@@ -520,15 +151,12 @@ public class OperatorXmlBuilder {
         if (Double.isNaN(value)) {
             throw new IllegalArgumentException("Cannot serialize NaN as a BEAST X XML number.");
         }
-
         if (value == Double.POSITIVE_INFINITY) {
             return "Infinity";
         }
-
         if (value == Double.NEGATIVE_INFINITY) {
             return "-Infinity";
         }
-
         return Double.toString(value);
     }
 }

--- a/integrations/beastx/java/src/test/java/BeastXIntegerOperatorSelectionTest.java
+++ b/integrations/beastx/java/src/test/java/BeastXIntegerOperatorSelectionTest.java
@@ -1,0 +1,102 @@
+import dr.inference.model.Parameter;
+import dr.inference.operators.MCMCOperator;
+import dr.inference.operators.RandomWalkIntegerOperator;
+import dr.inference.operators.RandomWalkOperator;
+import dr.inference.operators.SwapOperator;
+import dr.inference.operators.UniformIntegerOperator;
+import org.junit.jupiter.api.Test;
+import org.phylospec.domain.Int;
+import org.phylospec.tiling.TypeToken;
+import org.phylospec.types.IntScalar;
+import org.phylospec.types.IntVector;
+import tiling.BeastXState;
+import tiling.operators.OperatorBuilder;
+import tiling.params.BeastXIntScalarParam;
+import tiling.params.BeastXIntVectorParam;
+import tiling.xml.XmlElement;
+import tiling.xml.builders.OperatorXmlBuilder;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BeastXIntegerOperatorSelectionTest {
+
+    @Test
+    public void unboundedIntegerScalarUsesOnlyIntegerRandomWalk() {
+        Parameter parameter = new Parameter.Default(2.0);
+        parameter.addBounds(new Parameter.DefaultBounds(
+                Double.POSITIVE_INFINITY, 0, 1));
+
+        BeastXState state = new BeastXState("integer-scalar");
+        state.addStateNode(
+                new BeastXIntScalarParam<>(parameter, Int.INSTANCE),
+                new TypeToken<IntScalar<Int>>() {},
+                "count");
+
+        List<MCMCOperator> operators = new OperatorBuilder().build(state);
+
+        assertEquals(1, operators.size());
+        assertTrue(hasOperator(operators, RandomWalkIntegerOperator.class));
+        assertFalse(hasOperator(operators, RandomWalkOperator.class));
+        assertXmlTags(state, "randomWalkIntegerOperator");
+    }
+
+    @Test
+    public void boundedIntegerScalarAddsUniformButNotSwap() throws Exception {
+        BeastXState state = stateFrom(
+                "Integer count ~ DiscreteUniform(lower=1, upper=10)");
+
+        List<MCMCOperator> operators = new OperatorBuilder().build(state);
+
+        assertEquals(2, operators.size());
+        assertTrue(hasOperator(operators, RandomWalkIntegerOperator.class));
+        assertTrue(hasOperator(operators, UniformIntegerOperator.class));
+        assertFalse(hasOperator(operators, SwapOperator.class));
+        assertXmlTags(state, "randomWalkIntegerOperator", "uniformIntegerOperator");
+    }
+
+    @Test
+    public void boundedIntegerVectorUsesRandomWalkSwapAndUniform() {
+        Parameter parameter = new Parameter.Default(new double[]{0, 1, 2});
+        parameter.addBounds(new Parameter.DefaultBounds(3, 0, 3));
+
+        BeastXState state = new BeastXState("integer-vector");
+        state.addStateNode(
+                new BeastXIntVectorParam<>(parameter, Int.INSTANCE),
+                new TypeToken<IntVector<Int>>() {},
+                "categories");
+
+        List<MCMCOperator> operators = new OperatorBuilder().build(state);
+
+        assertEquals(3, operators.size());
+        assertTrue(hasOperator(operators, RandomWalkIntegerOperator.class));
+        assertTrue(hasOperator(operators, SwapOperator.class));
+        assertTrue(hasOperator(operators, UniformIntegerOperator.class));
+        assertXmlTags(
+                state,
+                "randomWalkIntegerOperator",
+                "swapOperator",
+                "uniformIntegerOperator");
+    }
+
+    private static BeastXState stateFrom(String source) throws Exception {
+        return new PhyloSpecRunner(source).buildModel("integer-operators").beastState;
+    }
+
+    private static boolean hasOperator(
+            List<MCMCOperator> operators,
+            Class<? extends MCMCOperator> type
+    ) {
+        return operators.stream().anyMatch(type::isInstance);
+    }
+
+    private static void assertXmlTags(BeastXState state, String... expectedTags) {
+        List<String> actualTags = new OperatorXmlBuilder().buildOperators(state).stream()
+                .map(XmlElement::tag)
+                .toList();
+        assertEquals(List.of(expectedTags), actualTags);
+    }
+}

--- a/integrations/beastx/java/src/test/java/BeastXMCMCBuilderTest.java
+++ b/integrations/beastx/java/src/test/java/BeastXMCMCBuilderTest.java
@@ -44,6 +44,8 @@ public class BeastXMCMCBuilderTest {
                     Real randomWalkWindowSize = 0.25
 
                     Real treeScaleWeight = 9.0
+                    Real treeRootScaleWeight = 6.0
+                    Real treeRootScaleFactor = 0.4
                     Real treeSubtreeSlideSize = 7.0
                     Real treeSubtreeSlideWeight = 11.0
                     Real treeNarrowExchangeWeight = 13.0
@@ -63,6 +65,8 @@ public class BeastXMCMCBuilderTest {
         assertEquals(0.25, state.operatorConfig.randomWalkWindowSize);
 
         assertEquals(9.0, state.operatorConfig.treeScaleWeight);
+        assertEquals(6.0, state.operatorConfig.treeRootScaleWeight);
+        assertEquals(0.4, state.operatorConfig.treeRootScaleFactor);
         assertEquals(7.0, state.operatorConfig.treeSubtreeSlideSize);
         assertEquals(11.0, state.operatorConfig.treeSubtreeSlideWeight);
         assertEquals(13.0, state.operatorConfig.treeNarrowExchangeWeight);
@@ -848,7 +852,7 @@ public class BeastXMCMCBuilderTest {
         List<MCMCOperator> operators =
                 buildOperators(source);
 
-        assertEquals(7, operators.size());
+        assertEquals(8, operators.size());
         assertTrue(containsOperator(operators, NodeHeightScaleOperator.class));
         assertTrue(containsOperator(operators, UniformNodeHeightOperator.class));
         assertTrue(containsOperator(operators, RandomWalkNodeHeightOperator.class));
@@ -883,7 +887,7 @@ public class BeastXMCMCBuilderTest {
         List<MCMCOperator> operators =
                 buildOperators(source);
 
-        assertEquals(9, operators.size());
+        assertEquals(10, operators.size());
 
         assertTrue(containsOperator(operators, ScaleOperator.class));
         assertTrue(containsOperator(operators, DeltaExchangeOperator.class));

--- a/integrations/beastx/java/src/test/java/BeastXMCMCBuilderTest.java
+++ b/integrations/beastx/java/src/test/java/BeastXMCMCBuilderTest.java
@@ -1,5 +1,4 @@
 import dr.evomodel.operators.ExchangeOperator;
-import dr.evomodel.operators.NodeHeightScaleOperator;
 import dr.evomodel.operators.RandomWalkNodeHeightOperator;
 import dr.evomodel.operators.SubtreeSlideOperator;
 import dr.evomodel.operators.UniformNodeHeightOperator;
@@ -853,7 +852,7 @@ public class BeastXMCMCBuilderTest {
                 buildOperators(source);
 
         assertEquals(8, operators.size());
-        assertTrue(containsOperator(operators, NodeHeightScaleOperator.class));
+        assertTrue(containsScaleOperatorForVariable(operators, "tree.allInternalNodeHeights"));
         assertTrue(containsOperator(operators, UniformNodeHeightOperator.class));
         assertTrue(containsOperator(operators, RandomWalkNodeHeightOperator.class));
         assertTrue(containsOperator(operators, SubtreeSlideOperator.class));
@@ -892,7 +891,7 @@ public class BeastXMCMCBuilderTest {
         assertTrue(containsOperator(operators, ScaleOperator.class));
         assertTrue(containsOperator(operators, DeltaExchangeOperator.class));
 
-        assertTrue(containsOperator(operators, NodeHeightScaleOperator.class));
+        assertTrue(containsScaleOperatorForVariable(operators, "tree.allInternalNodeHeights"));
         assertTrue(containsOperator(operators, UniformNodeHeightOperator.class));
         assertTrue(containsOperator(operators, RandomWalkNodeHeightOperator.class));
         assertTrue(containsOperator(operators, SubtreeSlideOperator.class));
@@ -921,6 +920,17 @@ public class BeastXMCMCBuilderTest {
                 .anyMatch(operatorClass::isInstance);
     }
 
+    private boolean containsScaleOperatorForVariable(
+            List<MCMCOperator> operators,
+            String variableId
+    ) {
+        return operators.stream()
+                .filter(ScaleOperator.class::isInstance)
+                .map(ScaleOperator.class::cast)
+                .map(ScaleOperator::getVariable)
+                .anyMatch(variable -> variableId.equals(variable.getId()));
+    }
+
     @Test
     public void buildsTreeClockUpDownOperatorForStrictClockModel() throws Exception {
         String source =
@@ -946,7 +956,7 @@ public class BeastXMCMCBuilderTest {
                 buildOperators(source);
 
         assertTrue(containsOperator(operators, ScaleOperator.class));
-        assertTrue(containsOperator(operators, NodeHeightScaleOperator.class));
+        assertTrue(containsScaleOperatorForVariable(operators, "tree.allInternalNodeHeights"));
         assertTrue(containsOperator(operators, ExchangeOperator.class));
         assertTrue(containsOperator(operators, WilsonBalding.class));
         assertTrue(containsOperator(operators, UpDownOperator.class));
@@ -977,7 +987,7 @@ public class BeastXMCMCBuilderTest {
                 buildOperators(source);
 
         assertTrue(containsOperator(operators, ScaleOperator.class));
-        assertTrue(containsOperator(operators, NodeHeightScaleOperator.class));
+        assertTrue(containsScaleOperatorForVariable(operators, "tree.allInternalNodeHeights"));
         assertTrue(containsOperator(operators, ExchangeOperator.class));
         assertTrue(containsOperator(operators, WilsonBalding.class));
         assertTrue(containsOperator(operators, UpDownOperator.class));

--- a/integrations/beastx/java/src/test/java/BeastXRepresentativeModelsTest.java
+++ b/integrations/beastx/java/src/test/java/BeastXRepresentativeModelsTest.java
@@ -58,7 +58,8 @@ public class BeastXRepresentativeModelsTest {
 
             if (!summary.treePriors.isEmpty()) {
                 assertTrue(
-                        summary.operators.contains("NodeHeightScaleOperator"),
+                        summary.operatorDetails.stream().anyMatch(detail ->
+                                detail.contains("ScaleOperator(treeNodeHeights=")),
                         "Stochastic tree model should have a tree height operator: " + modelPath
                 );
 
@@ -239,7 +240,6 @@ public class BeastXRepresentativeModelsTest {
                 summary.operators,
                 "DeltaExchangeOperator",
                 "ExchangeOperator",
-                "NodeHeightScaleOperator",
                 "RandomWalkIntegerOperator",
                 "ScaleOperator",
                 "SubtreeSlideOperator",
@@ -252,6 +252,7 @@ public class BeastXRepresentativeModelsTest {
         assertAnyContains(summary.operatorDetails, "RandomWalkIntegerOperator(parameter=branchRateCategories");
         assertAnyContains(summary.operatorDetails, "SwapOperator(parameter=branchRateCategories");
         assertAnyContains(summary.operatorDetails, "UniformIntegerOperator(parameter=branchRateCategories");
+        assertAnyContains(summary.operatorDetails, "ScaleOperator(treeNodeHeights=tree.allInternalNodeHeights");
         assertAnyContains(summary.operatorDetails, "ScaleOperator(parameter=clockRate");
         assertAnyContains(summary.operatorDetails, "ScaleOperator(parameter=diversificationRate");
         assertAnyContains(summary.operatorDetails, "ScaleOperator(parameter=serialSamplingRate");
@@ -311,7 +312,6 @@ public class BeastXRepresentativeModelsTest {
                 summary.operators,
                 "DeltaExchangeOperator",
                 "ExchangeOperator",
-                "NodeHeightScaleOperator",
                 "ScaleOperator",
                 "SubtreeSlideOperator",
                 "UpDownOperator",
@@ -330,6 +330,7 @@ public class BeastXRepresentativeModelsTest {
 
         assertAnyContains(summary.operatorDetails, "DeltaExchangeOperator(parameter=firstBaseFrequencies");
         assertAnyContains(summary.operatorDetails, "DeltaExchangeOperator(parameter=secondBaseFrequencies");
+        assertAnyContains(summary.operatorDetails, "ScaleOperator(treeNodeHeights=tree.allInternalNodeHeights");
         assertAnyContains(summary.operatorDetails, "ScaleOperator(parameter=clockRate");
         assertAnyContains(summary.operatorDetails, "ScaleOperator(parameter=firstShape");
         assertAnyContains(summary.operatorDetails, "ScaleOperator(parameter=secondShape");

--- a/integrations/beastx/java/src/test/java/BeastXRepresentativeModelsTest.java
+++ b/integrations/beastx/java/src/test/java/BeastXRepresentativeModelsTest.java
@@ -324,8 +324,8 @@ public class BeastXRepresentativeModelsTest {
         );
 
         assertTrue(
-                Collections.frequency(summary.operators, "UpDownOperator") >= 2,
-                "Partitioned clock/site model should have coupled clock-tree operators."
+                Collections.frequency(summary.operators, "UpDownOperator") >= 1,
+                "Partitioned clock/site model should have a coupled clock-tree operator."
         );
 
         assertAnyContains(summary.operatorDetails, "DeltaExchangeOperator(parameter=firstBaseFrequencies");

--- a/integrations/beastx/java/src/test/java/BeastXXmlNucleotidePhyloCTMCTest.java
+++ b/integrations/beastx/java/src/test/java/BeastXXmlNucleotidePhyloCTMCTest.java
@@ -712,11 +712,11 @@ public class BeastXXmlNucleotidePhyloCTMCTest {
         assertTrue(xml.contains("<rateCategories>"), xml);
         assertTrue(xml.contains("<treeLikelihood"), xml);
         assertTrue(xml.contains("<multiplicativeBranchRates idref="), xml);
-        assertFalse(xml.contains("branchRateCategories_randomWalk"), xml);
-        assertFalse(xml.contains("<narrowExchange"), xml);
-        assertFalse(xml.contains("<wideExchange"), xml);
-        assertFalse(xml.contains("<subtreeSlide"), xml);
-        assertFalse(xml.contains("<wilsonBalding"), xml);
+        assertTrue(xml.contains("branchRateCategories_randomWalk"), xml);
+        assertTrue(xml.contains("<narrowExchange"), xml);
+        assertTrue(xml.contains("<wideExchange"), xml);
+        assertTrue(xml.contains("<subtreeSlide"), xml);
+        assertTrue(xml.contains("<wilsonBalding"), xml);
 
         new XmlRunner()
                 .run(xmlPath);


### PR DESCRIPTION
## Summary

- centralize BEAST X operator selection in a shared `OperatorSelector`
- use the same operator specifications for direct and XML materialization
- add integer random-walk, swap, and uniform operators for integer parameters
- add root-scale and existing tree topology/height operators
- manage strict-clock tree/clock UpDown operators through dedicated joint selectors
- deduplicate repeated joint operators
- align relaxed-clock category operators between direct and XML paths
- add focused integer and representative-model tests

## Design

`OperatorSpec` represents selected operators independently of their output
format. `OperatorBuilder` and `OperatorXmlBuilder` materialize those shared
specifications for the direct and XML execution paths.

Joint operators are handled separately under the `operators/joint` package
because their selection depends on relationships between multiple state
nodes rather than a single parameter type.

## Validation

- focused BEAST X operator tests passed
- BEAST XML tree-prior parsing tests passed
- `git diff --check` passed

Boolean operators are intentionally excluded because BEAST X currently has
no corresponding Boolean state representation.